### PR TITLE
Support for non-daemon threads in the ConfigurationPoller

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,15 @@
+Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+
+Licensed under the Amazon Software License (the "License"). You may not use this 
+file except in compliance with the License. A copy of the License is located at
+  http://aws.amazon.com/asl/
+or in the "license" file accompanying this file. This file is distributed on 
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+implied. See the License for the specific language governing permissions and 
+limitations under the License. 
+
+Derived from spymemcached 2.8.1 under the MIT license. 
+ 
 Copyright (c) 2006-2009  Dustin Sallings
 Copyright (c) 2009-2011  Couchbase, Inc.
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,7 @@
+# Amazon ElastiCache Cluster Client
+
+Amazon ElastiCache Cluster Client is an enhanced Java library to connect to ElastiCache clusters. This client library has been built upon Spymemcached and is released under the [Amazon Software License](http://aws.amazon.com/asl/).
+
 # Building
 
 AmazonElastiCacheClusterClient can be compiled using Apache Ant by running the following
@@ -39,18 +43,7 @@ This repository is a fork of the spymemcached Java client for connecting to memc
 
 Additional changes have been made to support Amazon ElastiCache Auto Discovery. To read more about Auto Discovery, please go here: http://docs.amazonwebservices.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html.
 
-For more information about Spymemcached see the links below:
+For more information about Spymemcached see the link below:
 
 [Spymemcached Project Home](http://code.google.com/p/spymemcached/)
 contains a wiki, issue tracker, and downloads section.
-
-## Github
-
-[The gitub page](http://github.com/dustin/java-memcached-client)
-contains the latest Spymemcached source.
-
-## Couchbase.org
-
-At [couchbase.org](http://www.couchbase.org/code/couchbase/java) you
-can find a download's section for the latest release as well as an
-extensive tutorial to help new users learn how to use Spymemcached.

--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@ Amazon ElastiCache Cluster Client is an enhanced Java library to connect to Elas
 
 # Building
 
-AmazonElastiCacheClusterClient can be compiled using Apache Ant by running the following
+Amazon ElastiCache Cluster Client can be compiled using Apache Ant by running the following
 command:
 
     ant

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # Building
 
-Spymemcached can be compiled using Apache Ant by running the following
+AmazonElastiCacheClusterClient can be compiled using Apache Ant by running the following
 command:
 
     ant
@@ -8,20 +8,13 @@ command:
 This will generate binary, source, and javadoc jars in the build
 directory of the project.
 
-To run the Spymemcached tests against Membase Server run the
-following command:
-
-    ant test -Dserver.type=membase
-
-To test Spymemcached against Membase running on a different host
-use the following command:
-
-    ant test -Dserver.type=membase \
-        -Dserver.address_v4=ip_address_of_membase
+More test info will be updated shortly.
 
 # Testing
 
-The latest version of spymemcached has a set of command line arguments
+_Note: The ant test target is in the process of being updated to run the additional tests written for Auto Discovery._
+
+The latest version of AmazonElastiCacheClusterClient has a set of command line arguments
 that can be used to configure the location of your testing server. The
 arguments are listed below.
 
@@ -29,12 +22,6 @@ arguments are listed below.
 
 This argument is used to specify the ipv4 address of your testing
 server. By default it is set to localhost.
-
-    -Dserver.address_v6=ipv6_address_of_testing_server
-
-This argument is used to set the ipv6 address of your testing server.
-By default it is set to ::1. If an ipv6 address is specified then an
-ipv4 address must be specified otherwise there may be test failures.
 
     -Dserver.port_number=port_number_of_memcached
 
@@ -46,11 +33,13 @@ This argument is used when memcahched is started on a port other than
 This argument is used for CI testing where certain unit tests might
 be temporarily failing.
 
-# More Information
+# More Information for Amazon ElastiCache Cluster Client
+Github link: https://github.com/amazonwebservices/aws-elasticache-cluster-client-memcached-for-java
+This repository is a fork of the spymemcached Java client for connecting to memcached (specifically the https://github.com/dustin/java-memcached-client repo).
+
+Additional changes have been made to support Amazon ElastiCache Auto Discovery. To read more about Auto Discovery, please go here: http://docs.amazonwebservices.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html.
 
 For more information about Spymemcached see the links below:
-
-## Project Page The
 
 [Spymemcached Project Home](http://code.google.com/p/spymemcached/)
 contains a wiki, issue tracker, and downloads section.

--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,7 @@ More test info will be updated shortly.
 
 _Note: The ant test target is in the process of being updated to run the additional tests written for Auto Discovery._
 
-The latest version of AmazonElastiCacheClusterClient has a set of command line arguments
+The latest version of Amazon ElastiCache Cluster Client has a set of command line arguments
 that can be used to configure the location of your testing server. The
 arguments are listed below.
 

--- a/build.xml
+++ b/build.xml
@@ -18,9 +18,19 @@
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
+
+  Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   
+  Licensed under the Amazon Software License (the "License"). You may not use this 
+  file except in compliance with the License. A copy of the License is located at
+   http://aws.amazon.com/asl/
+  or in the "license" file accompanying this file. This file is distributed on 
+  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+  implied. See the License for the specific language governing permissions and 
+  limitations under the License.
 -->
 
-<project name="spymemcached" default="package"
+<project name="AmazonElastiCacheClusterClient" default="package"
     xmlns:artifact="urn:maven-artifact-ant"
     xmlns:ivy="antlib:org.apache.ivy.ant">
 
@@ -31,8 +41,8 @@
     </classpath>
   </taskdef>
 
-  <property name="name" value="spymemcached"/>
-  <property name="copyright" value="2006-2011 Dustin Sallings, Matt Ingenthron" />
+  <property name="name" value="AmazonElastiCacheClusterClient"/>
+  <property name="copyright" value="2006-2011 Dustin Sallings, Matt Ingenthron, 2012-2012 Amazon.com, Inc. or its affiliates" />
   <property name="group" value="spy" />
 
   <property name="base.src.dir" value="${basedir}/src" />

--- a/ivy/libraries.properties
+++ b/ivy/libraries.properties
@@ -17,6 +17,16 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+ 
+# Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  
+# Licensed under the Amazon Software License (the "License"). You may not use this 
+# file except in compliance with the License. A copy of the License is located at
+#  http://aws.amazon.com/asl/
+# or in the "license" file accompanying this file. This file is distributed on 
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+# implied. See the License for the specific language governing permissions and 
+# limitations under the License.
 
 checkstyle.version=5.0
 
@@ -26,6 +36,6 @@ ivy.version=2.2.0
 mvn.version=2.0.10
 
 jmock.version=1.2.0
-junit.version=4.7
+junit.version=4.8.2
 log4j.version=1.2.16
 spring-beans.version=3.0.3.RELEASE

--- a/ivy/spymemcached.xml
+++ b/ivy/spymemcached.xml
@@ -20,13 +20,23 @@
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
+
+  Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   
+  Licensed under the Amazon Software License (the "License"). You may not use this 
+  file except in compliance with the License. A copy of the License is located at
+   http://aws.amazon.com/asl/
+  or in the "license" file accompanying this file. This file is distributed on 
+  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+  implied. See the License for the specific language governing permissions and 
+  limitations under the License.
 -->
 <ivy-module version="1.0">
   <info organisation="spy" module="${name}" revision="${version}">
-    <license name="Apache 2.0"/>
-    <ivyauthor name="Couchbase" url="http://github.com/dustin/java-memcached-client" />
+    <license name="Amazon Software License"/>
+    <ivyauthor name="Amazon.com Inc" url="https://github.com/amazonwebservices/aws-elasticache-cluster-client-memcached-for-java" />
     <description>
-        Spymemcached
+        AmazonElastiCacheClusterClient
     </description>
   </info>
   <configurations defaultconfmapping="default">

--- a/src/main/java/net/spy/memcached/BinaryConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/BinaryConnectionFactory.java
@@ -19,6 +19,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached;
@@ -35,18 +46,39 @@ import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 public class BinaryConnectionFactory extends DefaultConnectionFactory {
 
   /**
-   * Create a DefaultConnectionFactory with the default parameters.
+   * Create a BinaryConnectionFactory with the default parameters.
    */
   public BinaryConnectionFactory() {
     super();
   }
+  
+  /**
+   * Create a BinaryConnectionFactory with the given clientMode.
+   * @param clientMode
+   */
+  public BinaryConnectionFactory(ClientMode clientMode){
+    super(clientMode);
+  }
 
   /**
-   * Create a BinaryConnectionFactory with the given maximum operation queue
-   * length, and the given read buffer size.
+   * Create a BinaryConnectionFactory with the given parameters
+   * 
+   * @param len the queue length.
+   * @param bufSize the buffer size
    */
   public BinaryConnectionFactory(int len, int bufSize) {
-    super(len, bufSize);
+    super(ClientMode.Dynamic, len, bufSize);
+  }
+
+  /**
+   * Create a BinaryConnectionFactory with the given parameters
+   * 
+   * @param clientMode the mode of the client to indicate whether dynamic server list management is done.
+   * @param len the queue length.
+   * @param bufSize the buffer size
+   */
+  public BinaryConnectionFactory(ClientMode clientMode, int len, int bufSize) {
+    super(clientMode, len, bufSize);
   }
 
   /**
@@ -57,7 +89,19 @@ public class BinaryConnectionFactory extends DefaultConnectionFactory {
    * @param hash the algorithm to use for hashing
    */
   public BinaryConnectionFactory(int len, int bufSize, HashAlgorithm hash) {
-    super(len, bufSize, hash);
+    super(ClientMode.Dynamic, len, bufSize, hash);
+  }
+
+  /**
+   * Construct a BinaryConnectionFactory with the given parameters.
+   *
+   * @param clientMode the mode of the client to indicate whether dynamic server list management is done.
+   * @param len the queue length.
+   * @param bufSize the buffer size
+   * @param hash the algorithm to use for hashing
+   */
+  public BinaryConnectionFactory(ClientMode clientMode, int len, int bufSize, HashAlgorithm hash) {
+    super(clientMode, len, bufSize, hash);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/ClientMode.java
+++ b/src/main/java/net/spy/memcached/ClientMode.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached;
+
+/**
+ * The modes in which the client can operate. 
+ */
+public enum ClientMode {
+
+  /**
+   * In Static Client mode, the set of endpoints specified during initialization is used throughout the lifetime of the client object.
+   */
+  Static,
+  /**
+   * In Dynamic Client mode, the set of cache node endpoints and any updates to it is dynamically managed in this mode. 
+   * The client is initialized with a configuration endpoint. The client will periodically learn about the cache nodes in the
+   * cluster.
+   */
+  Dynamic
+}

--- a/src/main/java/net/spy/memcached/ConfigurationPoller.java
+++ b/src/main/java/net/spy/memcached/ConfigurationPoller.java
@@ -115,6 +115,13 @@ public class ConfigurationPoller extends SpyThread{
               newConfigResponse = (String)client.getConfig(socketAddressToGetConfig, 
                                                                                          ConfigurationType.CLUSTER,
                                                                                          configTranscoder);
+              if(newConfigResponse == null || newConfigResponse.trim().isEmpty()){
+                newConfigResponse = (String)client.get(socketAddressToGetConfig, ConfigurationType.CLUSTER.getValueWithNameSpace(), configTranscoder);
+                if(newConfigResponse != null && ! newConfigResponse.trim().isEmpty()){
+                  client.setIsConfigurationProtocolSupported(false);
+                }
+              }
+
             }catch(OperationNotSupportedException e){
               //Fallback to key based config access.
               client.setIsConfigurationProtocolSupported(false);

--- a/src/main/java/net/spy/memcached/ConfigurationPoller.java
+++ b/src/main/java/net/spy/memcached/ConfigurationPoller.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import net.spy.memcached.compat.SpyThread;
+import net.spy.memcached.config.ClusterConfiguration;
+import net.spy.memcached.config.ClusterConfigurationObserver;
+import net.spy.memcached.config.NodeEndPoint;
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.transcoders.SerializingTranscoder;
+import net.spy.memcached.transcoders.Transcoder;
+
+/**
+ * A periodic poller to fetch configuration information from the server. This also acts as
+ * the publisher when there is change in the configuration.
+ *
+ */
+public class ConfigurationPoller extends SpyThread{
+
+  //5 second initial delay before starting poller.
+  private static final long INITIAL_DELAY = 5000l;
+  // 1 minute polling interval
+  public static final long DEFAULT_POLL_INTERVAL = 60000l;
+  private static final int MAX_RETRY_ATTEMPT = 3;
+  
+  //500 ms interval between retries;
+  private static final long RETRY_INTERVAL = 500l;
+  private final MemcachedClient client;
+  private List<ClusterConfigurationObserver> clusterConfigObservers = new ArrayList<ClusterConfigurationObserver>();
+  private String currentClusterConfigResponse;
+  private ClusterConfiguration currentClusterConfiguration;
+  //The transcoder used for config.
+  private Transcoder<Object> configTranscoder = new SerializingTranscoder();
+  private int currentIndex = 0;
+  private Date date = new Date();
+  private long lastSuccessfulPoll = date.getTime(); 
+  private int pollingErrorCount = 0;
+  
+  //The executor is used to keep the task and it's execution independent. The scheduled thread polls takes care of 
+  //the periodic polling.
+  private ScheduledThreadPoolExecutor scheduledExecutor = new ScheduledThreadPoolExecutor(1);
+  
+  public ConfigurationPoller(final MemcachedClient client){
+    this(client, DEFAULT_POLL_INTERVAL);
+  }
+  
+  public ConfigurationPoller(final MemcachedClient client, long pollingInterval){
+    this.client = client;
+    
+    //The explicit typed emptyList assignment avoids type warning.
+    List<NodeEndPoint> emptyList = Collections.emptyList();
+    this.currentClusterConfiguration = new ClusterConfiguration(-1, emptyList);
+    
+    //Keep the initial delay to few seconds to begin polling quickly. This is useful if the config API call timed out in Client constructor 
+    //and did not initialize the set of nodes in the cluster. The poller takes over the responsibility of configuring the client with the 
+    //nodes in the cluster.  
+    scheduledExecutor.scheduleAtFixedRate(this, INITIAL_DELAY, pollingInterval, TimeUnit.MILLISECONDS);
+  }
+  
+  public void subscribeForClusterConfiguration(ClusterConfigurationObserver observer){
+    clusterConfigObservers.add(observer);
+  }
+  
+  @Override
+  public void run(){
+    try{
+      getLogger().info("Starting configuration poller.");
+      String newConfigResponse = null;
+      NodeEndPoint endpointToGetConfig = null;
+    
+      Collection<NodeEndPoint> endpoints = client.getAvailableNodeEndPoints();
+      if(endpoints.isEmpty()){
+        //If no nodes are available status, then get all the endpoints. This provides an 
+        //oppurtunity to re-resolve the hostname by recreating InetSocketAddress instance in "NodeEndPoint".getInetSocketAddress().
+        endpoints = client.getAllNodeEndPoints();
+      }
+      currentIndex = (currentIndex+1)%endpoints.size();
+      Iterator<NodeEndPoint> iterator = endpoints.iterator();
+      for(int i =0;i<currentIndex;i++){
+        iterator.next();
+      }
+      
+      endpointToGetConfig = iterator.next();
+      InetSocketAddress socketAddressToGetConfig = endpointToGetConfig.getInetSocketAddress();
+      
+      getLogger().info("Endpoint to use for configuration access in this poll " + endpointToGetConfig.toString());
+      
+      int retryCount = 0;
+      
+      //If client is not initialized for the first time with the list of cache nodes, keep retrying till the call succeeds.
+      //To avoid execessive calls, there is a small retry interval between the retry attempts.
+      while(retryCount < MAX_RETRY_ATTEMPT || !client.isConfigurationInitialized()){
+        try{
+          if(client.isConfigurationProtocolSupported()){
+            try{
+              newConfigResponse = (String)client.getConfig(socketAddressToGetConfig, 
+                                                                                         ConfigurationType.CLUSTER,
+                                                                                         configTranscoder);
+            }catch(OperationNotSupportedException e){
+              //Fallback to key based config access.
+              client.setIsConfigurationProtocolSupported(false);
+              continue;
+            }
+          } else {
+            newConfigResponse = (String)client.get(socketAddressToGetConfig, 
+                                                                             ConfigurationType.CLUSTER.getValueWithNameSpace(), 
+                                                                             configTranscoder);
+          }
+          
+          //Operation succeeded and break out of the loop.
+          break;
+        }catch(OperationTimeoutException e){
+          retryCount++;
+          try{
+            Thread.sleep(RETRY_INTERVAL);
+          }catch (InterruptedException ex) {
+            getLogger().warn("Poller thread interrupted during the retry interval for config call. Continue with retry.", ex);
+          }
+          if(retryCount >= MAX_RETRY_ATTEMPT && client.isConfigurationInitialized()) { 
+            getLogger().warn("Max retry attempt reached for config call. Stopping the current poll cycle.", e);
+            return;
+          }else if(retryCount == MAX_RETRY_ATTEMPT - 1){
+            //Fall back to config endpoint
+            socketAddressToGetConfig = client.getConfigurationNode().getInetSocketAddress();
+          }else {
+            //Reresolve on retry attempt
+            socketAddressToGetConfig = endpointToGetConfig.getInetSocketAddress(true);
+          }
+        }
+      }
+      
+      if(newConfigResponse == null){
+        getLogger().warn("The configuration is null in the server " + endpointToGetConfig.getHostName());
+        trackPollingError();
+        return;
+      }
+      
+      getLogger().debug("Retrieved configuration value:" + newConfigResponse);
+      
+      if(newConfigResponse != null && !newConfigResponse.equals(currentClusterConfigResponse)){
+        ClusterConfiguration newClusterConfiguration = AddrUtil.parseClusterTypeConfiguration(newConfigResponse);
+        getLogger().warn("Change in configuration - Existing configuration: " + currentClusterConfiguration + "\n New configuration:" +  newClusterConfiguration);
+        if(newClusterConfiguration.getConfigVersion() > currentClusterConfiguration.getConfigVersion()){
+          currentClusterConfigResponse = newConfigResponse;
+          currentClusterConfiguration = newClusterConfiguration;
+          for(ClusterConfigurationObserver observer : clusterConfigObservers){
+            getLogger().info("Notifying observers about configuration change.");
+            observer.notifyUpdate(newClusterConfiguration);
+          }
+          if(!client.isConfigurationInitialized()){
+            client.setIsConfigurtionInitialized(true);
+          }
+        } else if(newClusterConfiguration.getConfigVersion() < currentClusterConfiguration.getConfigVersion()){
+          getLogger().info("Ignoring stale configuration - Existing configuration: " + currentClusterConfigResponse + "\n Stale configuration:" +  newConfigResponse);
+          trackPollingError();
+          return;
+        }
+      }
+      
+      pollingErrorCount = 0;
+      lastSuccessfulPoll = date.getTime();
+    }catch(Exception e){
+      getLogger().error("Error encountered in the poller. Current cluster configuration: " + currentClusterConfigResponse, e);
+      trackPollingError();
+    }
+  }
+  
+  private void trackPollingError(){
+    pollingErrorCount++;
+    getLogger().warn("Number of consecutive poller errors is " + Long.toString(pollingErrorCount) + 
+        ". Number of minutes since the last successful polling is " + Long.toString(date.getTime() - lastSuccessfulPoll));
+  }
+  
+  public void shutdown(){
+    scheduledExecutor.shutdownNow();
+  }
+  
+}

--- a/src/main/java/net/spy/memcached/ConfigurationTypeUtil.java
+++ b/src/main/java/net/spy/memcached/ConfigurationTypeUtil.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import net.spy.memcached.ops.ConfigurationType;
+
+/**
+ * Utilities for processing config types.
+ */
+public final class ConfigurationTypeUtil {
+
+  private ConfigurationTypeUtil() {
+    // Empty
+  }
+
+  /**
+   * Get the bytes for a config type.
+   *
+   * @param type the config type
+   * @return the bytes
+   */
+  public static byte[] getTypeBytes(ConfigurationType type) {
+    try {
+      String value = type.getValue();
+      return value.getBytes("UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Get the types in byte form for all of the config types.
+   *
+   * @param types a collection of types
+   * @return return a collection of the byte representations of config types
+   */
+  public static Collection<byte[]> getTypeBytes(Collection<ConfigurationType> types) {
+    Collection<byte[]> rv = new ArrayList<byte[]>(types.size());
+    for (ConfigurationType type : types) {
+      rv.add(getTypeBytes(type));
+    }
+    return rv;
+  }
+}

--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -18,6 +18,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached;
@@ -89,6 +100,18 @@ public interface ConnectionFactory {
    */
   OperationFactory getOperationFactory();
 
+  /**
+   * The mode in which the client is operating.
+   * @return the clientMode.
+   */
+  ClientMode getClientMode();
+  
+  /**
+   * The interval used for periodic polling of configuration. 
+   * @return the interval in milliseconds
+   */
+  long getDynamicModePollingInterval();
+  
   /**
    * Get the operation timeout used by this connection.
    */

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -19,6 +19,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached;
@@ -46,6 +57,8 @@ public class ConnectionFactoryBuilder {
 
   protected Transcoder<Object> transcoder;
 
+  protected ClientMode clientMode;
+  
   protected FailureMode failureMode;
 
   protected Collection<ConnectionObserver> initialObservers =
@@ -78,6 +91,7 @@ public class ConnectionFactoryBuilder {
   }
 
   public ConnectionFactoryBuilder(ConnectionFactory cf) {
+    setClientMode(cf.getClientMode());
     setAuthDescriptor(cf.getAuthDescriptor());
     setDaemon(cf.isDaemon());
     setFailureMode(cf.getFailureMode());
@@ -91,6 +105,16 @@ public class ConnectionFactoryBuilder {
     setTimeoutExceptionThreshold(cf.getTimeoutExceptionThreshold());
     setTranscoder(cf.getDefaultTranscoder());
     setUseNagleAlgorithm(cf.useNagleAlgorithm());
+  }
+
+  /**
+   * 
+   * @param clientMode
+   * @return
+   */
+  public ConnectionFactoryBuilder setClientMode(ClientMode clientMode){
+    this.clientMode = clientMode;
+    return this;
   }
 
   public ConnectionFactoryBuilder setOpQueueFactory(OperationQueueFactory q) {
@@ -162,7 +186,7 @@ public class ConnectionFactoryBuilder {
     opFact = f;
     return this;
   }
-
+  
   /**
    * Set the default operation timeout in milliseconds.
    */
@@ -270,6 +294,11 @@ public class ConnectionFactoryBuilder {
   public ConnectionFactory build() {
     return new DefaultConnectionFactory() {
 
+      @Override
+      public ClientMode getClientMode(){
+        return clientMode == null ? super.getClientMode() : clientMode;
+      }
+      
       @Override
       public BlockingQueue<Operation> createOperationQueue() {
         return opQueueFactory == null ? super.createOperationQueue()

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -60,6 +60,11 @@ public class DefaultConnectionFactory extends SpyObject implements
     ConnectionFactory {
 
   /**
+   * Default client mode.
+   */
+  public static final ClientMode DEFAULT_CLIENT_MODE = ClientMode.Dynamic;
+  
+  /**
    * Default failure mode.
    */
   public static final FailureMode DEFAULT_FAILURE_MODE =
@@ -93,7 +98,7 @@ public class DefaultConnectionFactory extends SpyObject implements
   /**
    * Default operation timeout in milliseconds.
    */
-  public static final long DEFAULT_OPERATION_TIMEOUT = 2500;
+  public static final long DEFAULT_OPERATION_TIMEOUT = 2500; //2500000;
 
   /**
    * Maximum amount of time (in seconds) to wait between reconnect attempts.
@@ -105,6 +110,7 @@ public class DefaultConnectionFactory extends SpyObject implements
    */
   public static final int DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD = 998;
 
+  private final ClientMode clientMode;
   protected final int opQueueLen;
   private final int readBufSize;
   private final HashAlgorithm hashAlg;
@@ -116,11 +122,20 @@ public class DefaultConnectionFactory extends SpyObject implements
    * @param bufSize the buffer size
    * @param hash the algorithm to use for hashing
    */
-  public DefaultConnectionFactory(int qLen, int bufSize, HashAlgorithm hash) {
+  public DefaultConnectionFactory(ClientMode clientMode, int qLen, int bufSize, HashAlgorithm hash) {
     super();
-    opQueueLen = qLen;
-    readBufSize = bufSize;
-    hashAlg = hash;
+    this.clientMode = clientMode;
+    this.opQueueLen = qLen;
+    this.readBufSize = bufSize;
+    this.hashAlg = hash;
+  }
+
+  /**
+   * Create a DefaultConnectionFactory with the given maximum operation queue
+   * length, and the given read buffer size.
+   */
+  public DefaultConnectionFactory(ClientMode clientMode, int qLen, int bufSize) {
+    this(clientMode, qLen, bufSize, DEFAULT_HASH);
   }
 
   /**
@@ -128,14 +143,26 @@ public class DefaultConnectionFactory extends SpyObject implements
    * length, and the given read buffer size.
    */
   public DefaultConnectionFactory(int qLen, int bufSize) {
-    this(qLen, bufSize, DEFAULT_HASH);
+    this(ClientMode.Dynamic, qLen, bufSize, DEFAULT_HASH);
   }
 
   /**
    * Create a DefaultConnectionFactory with the default parameters.
    */
+  public DefaultConnectionFactory(ClientMode clientMode) {
+    this(clientMode, DEFAULT_OP_QUEUE_LEN, DEFAULT_READ_BUFFER_SIZE);
+  }
+
   public DefaultConnectionFactory() {
-    this(DEFAULT_OP_QUEUE_LEN, DEFAULT_READ_BUFFER_SIZE);
+    this(DEFAULT_CLIENT_MODE, DEFAULT_OP_QUEUE_LEN, DEFAULT_READ_BUFFER_SIZE);
+  }
+
+  public ClientMode getClientMode(){
+    return clientMode;
+  }
+  
+  public long getDynamicModePollingInterval(){
+    return ConfigurationPoller.DEFAULT_POLL_INTERVAL;
   }
 
   public MemcachedNode createMemcachedNode(SocketAddress sa, SocketChannel c,

--- a/src/main/java/net/spy/memcached/KetamaConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/KetamaConnectionFactory.java
@@ -18,6 +18,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached;
@@ -47,16 +58,16 @@ public class KetamaConnectionFactory extends DefaultConnectionFactory {
    * @param opQueueMaxBlockTime the maximum time to block waiting for op
    *        queue operations to complete, in milliseconds
    */
-  public KetamaConnectionFactory(int qLen, int bufSize,
+  public KetamaConnectionFactory(ClientMode clientMode, int qLen, int bufSize,
       long opQueueMaxBlockTime) {
-    super(qLen, bufSize, DefaultHashAlgorithm.KETAMA_HASH);
+    super(clientMode, qLen, bufSize, DefaultHashAlgorithm.KETAMA_HASH);
   }
 
   /**
    * Create a KetamaConnectionFactory with the default parameters.
    */
   public KetamaConnectionFactory() {
-    this(DEFAULT_OP_QUEUE_LEN, DEFAULT_READ_BUFFER_SIZE,
+    this(DEFAULT_CLIENT_MODE, DEFAULT_OP_QUEUE_LEN, DEFAULT_READ_BUFFER_SIZE,
         DEFAULT_OP_QUEUE_MAX_BLOCK_TIME);
   }
 

--- a/src/main/java/net/spy/memcached/KetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/KetamaNodeLocator.java
@@ -48,7 +48,7 @@ import net.spy.memcached.util.KetamaNodeLocatorConfiguration;
 public final class KetamaNodeLocator extends SpyObject implements NodeLocator {
 
   private volatile TreeMap<Long, MemcachedNode> ketamaNodes;
-  private final Collection<MemcachedNode> allNodes;
+  private Collection<MemcachedNode> allNodes;
 
   private final HashAlgorithm hashAlg;
   private final KetamaNodeLocatorConfiguration config;
@@ -153,6 +153,7 @@ public final class KetamaNodeLocator extends SpyObject implements NodeLocator {
   @Override
   public void updateLocator(List<MemcachedNode> nodes) {
     setKetamaNodes(nodes);
+    allNodes = nodes;
   }
 
   /**

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -328,7 +328,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     }
     
     //Initialize and start the poller.
-    configPoller = new ConfigurationPoller(this, cf.getDynamicModePollingInterval());
+    configPoller = new ConfigurationPoller(this, cf.getDynamicModePollingInterval(), cf.isDaemon());
     configPoller.subscribeForClusterConfiguration(mconn);
   }
 

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -298,16 +298,21 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
       throws IOException{
     configurationNode = new NodeEndPoint(configurationEndPoint.getHostName(), configurationEndPoint.getPort());
     setupConnection(cf, Collections.singletonList(configurationEndPoint));
-    
-    String configResult;
+    boolean checkKey = false;
+    String configResult = null;
     try{
       try{
         //GetConfig
         configResult = (String)this.getConfig(configurationEndPoint, ConfigurationType.CLUSTER, configTranscoder);
       }catch(OperationNotSupportedException e){
-        
+        checkKey = true;
+      }
+
+      if(checkKey || configResult == null || configResult.trim().isEmpty()){
         configResult = (String)this.get(configurationEndPoint, ConfigurationType.CLUSTER.getValueWithNameSpace(), configTranscoder);
-        isConfigurationProtocolSupported = false;
+        if(configResult != null && ! configResult.trim().isEmpty()){
+          isConfigurationProtocolSupported = false;
+        }
       }
       
       if(configResult != null && ! configResult.trim().isEmpty()){

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -19,6 +19,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
  */
 
 package net.spy.memcached;
@@ -29,6 +40,7 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -48,26 +60,36 @@ import java.util.concurrent.atomic.AtomicReference;
 import net.spy.memcached.auth.AuthDescriptor;
 import net.spy.memcached.auth.AuthThreadMonitor;
 import net.spy.memcached.compat.SpyObject;
+import net.spy.memcached.config.ClusterConfiguration;
+import net.spy.memcached.ConfigurationPoller;
+import net.spy.memcached.config.NodeEndPoint;
 import net.spy.memcached.internal.BulkFuture;
 import net.spy.memcached.internal.BulkGetFuture;
+import net.spy.memcached.internal.GetConfigFuture;
 import net.spy.memcached.internal.GetFuture;
 import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.internal.SingleElementInfiniteIterator;
 import net.spy.memcached.ops.CASOperationStatus;
 import net.spy.memcached.ops.CancelledOperationStatus;
 import net.spy.memcached.ops.ConcatenationType;
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.DeleteConfigOperation;
 import net.spy.memcached.ops.DeleteOperation;
 import net.spy.memcached.ops.GetAndTouchOperation;
+import net.spy.memcached.ops.GetConfigOperation;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.GetsOperation;
 import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationErrorType;
+import net.spy.memcached.ops.OperationException;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StatsOperation;
 import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.ops.TimedOutOperationStatus;
+import net.spy.memcached.transcoders.SerializingTranscoder;
 import net.spy.memcached.transcoders.TranscodeService;
 import net.spy.memcached.transcoders.Transcoder;
 import net.spy.memcached.util.StringUtils;
@@ -78,8 +100,15 @@ import net.spy.memcached.util.StringUtils;
  * <h2>Basic usage</h2>
  *
  * <pre>
+ * The Client can be run in static mode or dynamic mode. In basic usage the mode is automatically 
+ * determined based on the endpoint specified. If the endpoint has cfg subdomain, then the client is
+ * initialized in dynamic mode.
+ *  
+ * // Use dynamic mode to leverage Elasticache Autodiscovery feature.
+ * // In dynamic mode, the number of servers in the cluster and their endpoint details are automatically picked up
+ * // using the configuration endpoint of the elasticache cluster.
  * MemcachedClient c = new MemcachedClient(
- *    new InetSocketAddress(&quot;hostname&quot;, portNum));
+ *    new InetSocketAddress(&quot;configurationEndpoint&quot;, portNum));
  *
  * // Store a value (async) for one hour
  * c.set(&quot;someKey&quot;, 3600, someObject);
@@ -87,6 +116,8 @@ import net.spy.memcached.util.StringUtils;
  * Object myObject = c.get(&quot;someKey&quot;);
  * </pre>
  *
+ * In the basic usage with out connection factory, the client mode is automatically determined 
+ * 
  * <h2>Advanced Usage</h2>
  *
  * <p>
@@ -100,10 +131,15 @@ import net.spy.memcached.util.StringUtils;
  * </p>
  *
  * <pre>
- *      // Get a memcached client connected to several servers
- *      // over the binary protocol
- *      MemcachedClient c = new MemcachedClient(new BinaryConnectionFactory(),
- *              AddrUtil.getAddresses("server1:11211 server2:11211"));
+ *      // Get a memcached client connected over the binary protocol
+ *      // The number of servers in the cluster and their endpoint details are automatically picked up
+ *      // using the configuration endpoint of the elasticache cluster. 
+ *      MemcachedClient c = new MemcachedClient(new BinaryConnectionFactory(ClientMode.Dynamic),
+ *              AddrUtil.getAddresses("configurationEndpoint:11211"));
+ *              // or //
+ *  // For operating with out the autodiscovery feature, use static mode(ClientMode.Static)
+ *      MemcachedClient c = new MemcachedClient(new BinaryConnectionFactory(ClientMode.Static),
+ *              AddrUtil.getAddresses("configurationEndpoint:11211"));
  *
  *      // Try to get a value, for up to 5 seconds, and cancel if it
  *      // doesn't return
@@ -125,11 +161,13 @@ import net.spy.memcached.util.StringUtils;
 public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     ConnectionObserver {
 
+  protected final ClientMode clientMode;
+  
   protected volatile boolean shuttingDown = false;
 
   protected final long operationTimeout;
 
-  protected final MemcachedConnection mconn;
+  protected MemcachedConnection mconn;
 
   protected final OperationFactory opFact;
 
@@ -143,15 +181,28 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
 
   protected final AuthThreadMonitor authMonitor = new AuthThreadMonitor();
 
+  private NodeEndPoint configurationNode;
+  //Set default value to true to attempt config API first. The value is set to false if
+  //OperationNotSupportedException is thrown.
+  private boolean isConfigurationProtocolSupported = true;
+  
+  //This is used to dynamic mode to track whether the client is initialized with set of cache nodes for the first time.
+  private boolean isConfigurationInitialized = false;
+  
+  private Transcoder<Object> configTranscoder = new SerializingTranscoder();
+  
+  private ConfigurationPoller configPoller;
+  
   /**
    * Get a memcache client operating on the specified memcached locations.
-   *
-   * @param ia the memcached locations
-   * @throws IOException if connections cannot be established
+   * 
+   * @param addrs the memcached locations
+   * @throws IOException
    */
-  public MemcachedClient(InetSocketAddress... ia) throws IOException {
-    this(new DefaultConnectionFactory(), Arrays.asList(ia));
-  }
+  public MemcachedClient(InetSocketAddress... addrs) throws IOException {
+    //The connectionFactory is created later based on client mode.
+    this(null, Arrays.asList(addrs), true);
+   }
 
   /**
    * Get a memcache client over the specified memcached locations.
@@ -160,9 +211,14 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    * @throws IOException if connections cannot be established
    */
   public MemcachedClient(List<InetSocketAddress> addrs) throws IOException {
-    this(new DefaultConnectionFactory(), addrs);
+    //The connectionFactory is created later based on client mode.
+    this(null, addrs, true);
   }
 
+  public MemcachedClient(ConnectionFactory cf, List<InetSocketAddress> addrs) throws IOException{
+    this(cf, addrs, false);
+  }
+  
   /**
    * Get a memcache client over the specified memcached locations.
    *
@@ -170,11 +226,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    * @param addrs the socket addresses
    * @throws IOException if connections cannot be established
    */
-  public MemcachedClient(ConnectionFactory cf, List<InetSocketAddress> addrs)
-    throws IOException {
-    if (cf == null) {
-      throw new NullPointerException("Connection factory required");
-    }
+  private MemcachedClient(ConnectionFactory cf, List<InetSocketAddress> addrs, boolean determineClientMode) throws IOException{
     if (addrs == null) {
       throw new NullPointerException("Server list required");
     }
@@ -182,21 +234,109 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
       throw new IllegalArgumentException("You must have at least one server to"
           + " connect to");
     }
+    
+    //An internal customer convenience check to determine whether the client mode based on 
+    // the DNS name if only one endpoint is specified. 
+    if(determineClientMode){
+      if(addrs.size() == 1){
+        if(addrs.get(0) == null){
+          throw new NullPointerException("Socket address is null");
+        }
+        String hostName = addrs.get(0).getHostName();
+        //All config endpoints has ".cfg." subdomain in the DNS name.
+        if(hostName != null && hostName.contains(".cfg.")){
+          cf = new DefaultConnectionFactory(ClientMode.Dynamic);
+        }
+      }
+      //Fallback to static mode
+      if(cf == null){
+        cf = new DefaultConnectionFactory(ClientMode.Static);
+      }
+    }
+
+    if (cf == null) {
+      throw new NullPointerException("Connection factory required");
+    }
+
     if (cf.getOperationTimeout() <= 0) {
       throw new IllegalArgumentException("Operation timeout must be positive.");
     }
+
+    if(cf.getClientMode() == ClientMode.Dynamic && addrs.size() > 1){
+      throw new IllegalArgumentException("Only one configuration endpoint is valid with dynamic client mode.");
+    }
+    
+    
     connFactory = cf;
+    clientMode = cf.getClientMode();
     tcService = new TranscodeService(cf.isDaemon());
     transcoder = cf.getDefaultTranscoder();
     opFact = cf.getOperationFactory();
     assert opFact != null : "Connection factory failed to make op factory";
-    mconn = cf.createConnection(addrs);
-    assert mconn != null : "Connection factory failed to make a connection";
+    
     operationTimeout = cf.getOperationTimeout();
     authDescriptor = cf.getAuthDescriptor();
     if (authDescriptor != null) {
       addObserver(this);
     }
+    
+    if(clientMode == ClientMode.Dynamic){
+      initializeClientUsingConfigEndPoint(cf, addrs.get(0));
+    } else {
+      setupConnection(cf, addrs);
+    }
+  }
+  
+  /**
+   * Establish a connection to the configuration endpoint and get the list of cache node endpoints. Then initialize the 
+   * memcached client with the cache node endpoints list. 
+   * @param cf
+   * @param addrs
+   * @throws IOException
+   */
+  private void initializeClientUsingConfigEndPoint(ConnectionFactory cf, InetSocketAddress configurationEndPoint) 
+      throws IOException{
+    configurationNode = new NodeEndPoint(configurationEndPoint.getHostName(), configurationEndPoint.getPort());
+    setupConnection(cf, Collections.singletonList(configurationEndPoint));
+    
+    String configResult;
+    try{
+      try{
+        //GetConfig
+        configResult = (String)this.getConfig(configurationEndPoint, ConfigurationType.CLUSTER, configTranscoder);
+      }catch(OperationNotSupportedException e){
+        
+        configResult = (String)this.get(configurationEndPoint, ConfigurationType.CLUSTER.getValueWithNameSpace(), configTranscoder);
+        isConfigurationProtocolSupported = false;
+      }
+      
+      if(configResult != null && ! configResult.trim().isEmpty()){
+        //Parse configuration to get the list of cache servers.
+        ClusterConfiguration clusterConfiguration = AddrUtil.parseClusterTypeConfiguration(configResult);
+        
+        //Initialize client with the actual set of endpoints.
+        mconn.notifyUpdate(clusterConfiguration);
+        isConfigurationInitialized = true;
+      }
+    }catch(OperationTimeoutException e){
+      getLogger().warn("Configuration endpoint timed out for config call. Leaving the initialization work to configuration poller.");
+    }
+    
+    //Initialize and start the poller.
+    configPoller = new ConfigurationPoller(this, cf.getDynamicModePollingInterval());
+    configPoller.subscribeForClusterConfiguration(mconn);
+  }
+
+  private void setupConnection(ConnectionFactory cf, List<InetSocketAddress> addrs)
+    throws IOException {
+
+    mconn = cf.createConnection(addrs);
+    assert mconn != null : "Connection factory failed to make a connection";
+
+  }
+  
+  public NodeEndPoint getConfigurationNode(){
+    return configurationNode;
   }
 
   /**
@@ -217,6 +357,43 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
         rv.add(node.getSocketAddress());
       }
     }
+    return rv;
+  }
+  
+  /**
+   * Get the endpoints of available servers. 
+   * Use this method instead of "getAvailableServers" if details about hostname, ipAddress and port of the servers
+   * are required. 
+   *  
+   * <p>
+   * This is based on a snapshot in time so shouldn't be considered completely
+   * accurate, but is a useful for getting a feel for what's working and what's
+   * not working.
+   * </p>
+   *
+   * @return point-in-time view of currently available servers
+   */
+  public Collection<NodeEndPoint> getAvailableNodeEndPoints() {
+    ArrayList<NodeEndPoint> rv = new ArrayList<NodeEndPoint>();
+    for (MemcachedNode node : mconn.getLocator().getAll()) {
+      if (node.isActive()) {
+        rv.add(node.getNodeEndPoint());
+      }
+    }
+    return rv;
+  }
+  
+  /**
+   * Get the endpoints of all servers. 
+   *  
+   * @return point-in-time view of current list of servers
+   */
+  public Collection<NodeEndPoint> getAllNodeEndPoints() {
+    ArrayList<NodeEndPoint> rv = new ArrayList<NodeEndPoint>();
+    for (MemcachedNode node : mconn.getLocator().getAll()) {
+        rv.add(node.getNodeEndPoint());
+    }
+    
     return rv;
   }
 
@@ -270,6 +447,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
 
   private CountDownLatch broadcastOp(BroadcastOpFactory of,
       Collection<MemcachedNode> nodes, boolean checkShuttingDown) {
+    checkState();
     if (checkShuttingDown && shuttingDown) {
       throw new IllegalStateException("Shutting down");
     }
@@ -293,7 +471,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
             }
           });
     rv.setOperation(op);
-    mconn.enqueueOperation(key, op);
+    enqueueOperation(key, op);
     return rv;
   }
 
@@ -319,7 +497,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
           }
         });
     rv.setOperation(op);
-    mconn.enqueueOperation(key, op);
+    enqueueOperation(key, op);
     return rv;
   }
 
@@ -365,7 +543,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
       }
     });
     rv.setOperation(op);
-    mconn.enqueueOperation(key, op);
+    enqueueOperation(key, op);
     return rv;
   }
 
@@ -503,7 +681,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
             }
           });
     rv.setOperation(op);
-    mconn.enqueueOperation(key, op);
+    enqueueOperation(key, op);
     return rv;
   }
 
@@ -832,7 +1010,67 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
       }
     });
     rv.setOperation(op);
-    mconn.enqueueOperation(key, op);
+    enqueueOperation(key, op);
+    return rv;
+  }
+  
+  /**
+   * Get with a single key from the specified node.
+   *
+   * @param <T>
+   * @param key the key to get
+   * @param tc the transcoder to serialize and unserialize value
+   * @return the result from the cache (null if there is none)
+   * @throws OperationTimeoutException if the global operation timeout is
+   *           exceeded
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  <T> T get(InetSocketAddress sa, final String key, final Transcoder<T> tc) {
+    try{
+      return asyncGet(sa, key, tc).get(operationTimeout, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted waiting for value", e);
+    } catch (ExecutionException e) {
+      throw new RuntimeException("Exception waiting for value", e);
+    } catch (TimeoutException e) {
+      throw new OperationTimeoutException("Timeout waiting for value", e);
+    }
+  }
+  /**
+   * Get the given key from the specified node.
+   * @param <T>
+   * @param sa - The InetSocketAddress of the node from which to fetch the key 
+   * @param key the key to fetch
+   * @param transcoder the transcoder to serialize and unserialize value
+   * @return a future that will hold the return value of the fetch
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  <T> GetFuture<T> asyncGet(InetSocketAddress sa, final String key, final Transcoder<T> tc) {
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final GetFuture<T> rv = new GetFuture<T>(latch, operationTimeout, key);
+    Operation op = opFact.get(key, new GetOperation.Callback() {
+      private Future<T> val = null;
+
+      public void receivedStatus(OperationStatus status) {
+        rv.set(val, status);
+      }
+
+      public void gotData(String k, int flags, byte[] data) {
+        assert key.equals(k) : "Wrong key returned";
+        val =
+            tcService.decode(tc, new CachedData(flags, data, transcoder.getMaxSize()));
+      }
+
+      public void complete() {
+        latch.countDown();
+      }
+    });
+    rv.setOperation(op);
+    mconn.enqueueOperation(sa, op);
+    
     return rv;
   }
 
@@ -885,7 +1123,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
       }
     });
     rv.setOperation(op);
-    mconn.enqueueOperation(key, op);
+    enqueueOperation(key, op);
     return rv;
   }
 
@@ -1018,6 +1256,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     return get(key, transcoder);
   }
 
+  
   /**
    * Asynchronously get a bunch of objects from the cache.
    *
@@ -1269,7 +1508,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
           }
         });
     rv.setOperation(op);
-    mconn.enqueueOperation(key, op);
+    enqueueOperation(key, op);
     return rv;
   }
 
@@ -1373,6 +1612,177 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   public Map<String, Object> getBulk(String... keys) {
     return getBulk(Arrays.asList(keys), transcoder);
   }
+  
+  private void enqueueOperation(String key, Operation op){
+    checkState();
+    mconn.enqueueOperation(key, op);
+  }
+  
+  private void checkState() {
+    if (clientMode == ClientMode.Dynamic && !isConfigurationInitialized) {
+      throw new IllegalStateException("Client is not initialized");
+    }
+  }
+  
+  /**
+   * Get the config
+   *
+   * @param addr - The node from which to retrieve the configuration
+   * @param type - config to get
+   * @return the result from the server.
+   * @throws OperationTimeoutException if the global operation timeout is
+   *           exceeded
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public Object getConfig(InetSocketAddress addr, ConfigurationType type) {
+    return getConfig(addr, type, transcoder);
+  }
+
+  /**
+   * Get the config using the config protocol.
+   * The command format is "config get <type>"
+   * @param addr - The node from which to retrieve the configuration
+   * @param config to get
+   * @param tc the transcoder to serialize and unserialize value
+   * @return the result from the server (null if there is none)
+   * @throws OperationTimeoutException if the global operation timeout is
+   *           exceeded
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public <T> T getConfig(InetSocketAddress addr, ConfigurationType type, Transcoder<T> tc) {
+    try {
+      return asyncGetConfig(addr, type, tc).get(operationTimeout, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted waiting for config", e);
+    } catch(OperationNotSupportedException e){
+      throw e;
+    } catch (ExecutionException e) {
+      if(e.getCause() instanceof OperationException){
+        OperationException exp = (OperationException)e.getCause();
+        if(OperationErrorType.GENERAL.equals(exp.getType())){
+          throw new OperationNotSupportedException("This version of getConfig command is not supported.");
+        }
+      }
+      throw new RuntimeException("Exception waiting for config", e);
+    } catch (TimeoutException e) {
+      throw new OperationTimeoutException("Timeout waiting for config", e);
+    }
+  }
+  
+  /**
+   * Get the given configurationType asynchronously.
+   *
+   * @param addr - The node from which to retrieve the configuration
+   * @param configurationType the configurationType to fetch
+   * @param tc the transcoder to serialize and unserialize value
+   * @return a future that will hold the return value of the fetch
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public <T> GetConfigFuture<T> asyncGetConfig(InetSocketAddress addr, final ConfigurationType type, final Transcoder<T> tc) {
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final GetConfigFuture<T> rv = new GetConfigFuture<T>(latch, operationTimeout, type);
+    Operation op = opFact.getConfig(type, new GetConfigOperation.Callback() {
+      private Future<T> val = null;
+
+      public void receivedStatus(OperationStatus status) {
+        rv.set(val, status);
+      }
+
+      public void gotData(ConfigurationType configurationType, int flags, byte[] data) {
+        assert type.equals(configurationType) : "Wrong type returned";
+        val =
+            tcService.decode(tc, new CachedData(flags, data, tc.getMaxSize()));
+      }
+
+      public void complete() {
+        latch.countDown();
+      }
+    });
+    rv.setOperation(op);
+    mconn.enqueueOperation(addr, op);
+    return rv;
+  }
+  
+  /**
+   * Sets the configuration in the cache node for the specified configurationType.
+   *
+   * @param addr - The node where the configuration is set.
+   * @param type the type under which this configuration should be added.
+   * @param o the configuration to store
+   * @return a future representing the processing of this operation
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public OperationFuture<Boolean> setConfig(InetSocketAddress addr, ConfigurationType configurationType, Object o) {
+    return asyncSetConfig(addr, configurationType, o, transcoder);
+  }
+
+  /**
+   * Sets the configuration in the cache node for the specified configurationType.
+   *
+   * @param addr - The node where the configuration is set.
+   * @param type the type under which this configuration should be added.
+   * @param o the configuration to store
+   * @param tc the transcoder to serialize and unserialize the configuration
+   * @return a future representing the processing of this operation
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public <T> OperationFuture<Boolean> setConfig(InetSocketAddress addr, ConfigurationType configurationType, Object o, Transcoder<T> tc) {
+    return asyncSetConfig(addr, configurationType, o, transcoder);
+  }
+
+  private <T> OperationFuture<Boolean> asyncSetConfig(InetSocketAddress addr, 
+      ConfigurationType configurationType, T value, Transcoder<T> tc) {
+    CachedData co = tc.encode(value);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final OperationFuture<Boolean> rv =
+        new OperationFuture<Boolean>(configurationType.getValue(), latch, operationTimeout);
+    Operation op = opFact.setConfig(configurationType, co.getFlags(), co.getData(),
+        new OperationCallback() {
+            public void receivedStatus(OperationStatus val) {
+              rv.set(val.isSuccess(), val);
+            }
+
+            public void complete() {
+              latch.countDown();
+            }
+          });
+    rv.setOperation(op);
+    mconn.enqueueOperation(addr, op);
+    return rv;
+  }
+
+  /**
+   * Delete the given configurationType from the cache server.
+   *
+   * @param addr - The node in which the configuration is deleted.
+   * @param configurationType the configurationType to delete
+   * @return whether or not the operation was performed
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public OperationFuture<Boolean> deleteConfig(InetSocketAddress addr, ConfigurationType configurationType) {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final OperationFuture<Boolean> rv = new OperationFuture<Boolean>(configurationType.getValue(),
+        latch, operationTimeout);
+    DeleteConfigOperation op = opFact.deleteConfig(configurationType, new OperationCallback() {
+      public void receivedStatus(OperationStatus s) {
+        rv.set(s.isSuccess(), s);
+      }
+
+      public void complete() {
+        latch.countDown();
+      }
+    });
+    rv.setOperation(op);
+    mconn.enqueueOperation(addr, op);
+    return rv;
+  }
 
   /**
    * Get the versions of all of the connected memcacheds.
@@ -1466,7 +1876,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   private long mutate(Mutator m, String key, long by, long def, int exp) {
     final AtomicLong rv = new AtomicLong();
     final CountDownLatch latch = new CountDownLatch(1);
-    mconn.enqueueOperation(key, opFact.mutate(m, key, by, def, exp,
+    enqueueOperation(key, opFact.mutate(m, key, by, def, exp,
         new OperationCallback() {
         public void receivedStatus(OperationStatus s) {
           // XXX: Potential abstraction leak.
@@ -1693,7 +2103,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
             latch.countDown();
           }
         });
-    mconn.enqueueOperation(key, op);
+    enqueueOperation(key, op);
     rv.setOperation(op);
     return rv;
   }
@@ -1860,7 +2270,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
       }
     });
     rv.setOperation(op);
-    mconn.enqueueOperation(key, op);
+    enqueueOperation(key, op);
     return rv;
   }
 
@@ -2006,6 +2416,9 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     } finally {
       // But always begin the shutdown sequence
       try {
+        if(clientMode == ClientMode.Dynamic){
+          configPoller.shutdown();
+        }
         mconn.setName(baseName + " - SHUTTING DOWN (telling client)");
         mconn.shutdown();
         mconn.setName(baseName + " - SHUTTING DOWN (informed client)");
@@ -2106,6 +2519,22 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     // Don't care.
   }
 
+  public boolean isConfigurationProtocolSupported(){
+    return isConfigurationProtocolSupported;
+  }
+
+  void setIsConfigurationProtocolSupported(boolean isConfigurationProtocolSupported){
+    this.isConfigurationProtocolSupported = isConfigurationProtocolSupported;                                                                           
+  }
+
+  public boolean isConfigurationInitialized(){
+    return isConfigurationInitialized;
+  }
+  
+  void setIsConfigurtionInitialized(boolean isConfigurationInitialized){
+    this.isConfigurationInitialized = isConfigurationInitialized;
+  }
+  
   @Override
   public String toString() {
     return connFactory.toString();

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -19,17 +19,30 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
 
+import net.spy.memcached.config.NodeEndPoint;
 import net.spy.memcached.ops.Operation;
 
 /**
@@ -134,7 +147,18 @@ public interface MemcachedNode {
    * Get the SocketAddress of the server to which this node is connected.
    */
   SocketAddress getSocketAddress();
-
+  
+  /**
+   * Get NodeEndPoint
+   * @return
+   */
+  NodeEndPoint getNodeEndPoint();
+  
+  /**
+   * Set NodeEndPoint
+   */
+  void setNodeEndPoint(NodeEndPoint endPoint);
+  
   /**
    * True if this node is <q>active.</q> i.e. is is currently connected and
    * expected to be able to process requests

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -19,6 +19,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached;
@@ -30,6 +41,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
 
+import net.spy.memcached.config.NodeEndPoint;
 import net.spy.memcached.ops.Operation;
 
 class MemcachedNodeROImpl implements MemcachedNode {
@@ -104,6 +116,14 @@ class MemcachedNodeROImpl implements MemcachedNode {
 
   public SocketAddress getSocketAddress() {
     return root.getSocketAddress();
+  }
+  
+  public NodeEndPoint getNodeEndPoint(){
+    return root.getNodeEndPoint();
+  }
+  
+  public void setNodeEndPoint(NodeEndPoint endPoint){
+    root.setNodeEndPoint(endPoint);
   }
 
   public ByteBuffer getWbuf() {

--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -19,6 +19,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached;
@@ -31,9 +42,12 @@ import javax.security.auth.callback.CallbackHandler;
 import net.spy.memcached.ops.CASOperation;
 import net.spy.memcached.ops.ConcatenationOperation;
 import net.spy.memcached.ops.ConcatenationType;
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.DeleteConfigOperation;
 import net.spy.memcached.ops.DeleteOperation;
 import net.spy.memcached.ops.FlushOperation;
 import net.spy.memcached.ops.GetAndTouchOperation;
+import net.spy.memcached.ops.GetConfigOperation;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.GetlOperation;
 import net.spy.memcached.ops.GetsOperation;
@@ -46,6 +60,7 @@ import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.SASLAuthOperation;
 import net.spy.memcached.ops.SASLMechsOperation;
 import net.spy.memcached.ops.SASLStepOperation;
+import net.spy.memcached.ops.SetConfigOperation;
 import net.spy.memcached.ops.StatsOperation;
 import net.spy.memcached.ops.StoreOperation;
 import net.spy.memcached.ops.StoreType;
@@ -146,6 +161,35 @@ public interface OperationFactory {
    * @return a new GetOperation
    */
   GetOperation get(Collection<String> keys, GetOperation.Callback cb);
+
+  /**
+   * Create a getConfig operation.
+   *
+   * @param type the config type to get
+   * @param cb the callback that will contain the results
+   * @return a new GetConfigOperation
+   */
+  GetConfigOperation getConfig(ConfigurationType type, GetConfigOperation.Callback cb);
+  
+  /**
+   * Create a setConfig operation.
+   *
+   * @param type the config type to set
+   * @param flags the config flags
+   * @param data the data
+   * @param cb the status callback
+   * @return a new SetConfigOperation
+   */
+  SetConfigOperation setConfig(ConfigurationType type, int flags, byte[] data, OperationCallback cb);
+  
+  /**
+   * Create a deletion operation for config.
+   *
+   * @param type the configuration type to delete
+   * @param operationCallback the status callback
+   * @return the new DeleteConfigOperation
+   */
+  DeleteConfigOperation deleteConfig(ConfigurationType type, OperationCallback operationCallback);
 
   /**
    * Create a mutator operation.

--- a/src/main/java/net/spy/memcached/OperationNotSupportedException.java
+++ b/src/main/java/net/spy/memcached/OperationNotSupportedException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached;
+
+/**
+ * Thrown by {@link MemcachedClient} when the operation is not supported. 
+ *
+ */
+public class OperationNotSupportedException extends RuntimeException {
+
+  private static final long serialVersionUID = 8270943033252267083L;
+
+  public OperationNotSupportedException(String message) {
+    super(message);
+  }
+
+  public OperationNotSupportedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/net/spy/memcached/config/ClusterConfiguration.java
+++ b/src/main/java/net/spy/memcached/config/ClusterConfiguration.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.net.InetSocketAddress;
+
+/**
+ * A type to capture the configuration version number and the server list 
+ * contained the response for getConfig API for "cluster" configuration type.
+ */
+public class ClusterConfiguration {
+
+  private long configVersion;
+  private List<NodeEndPoint> cacheNodeEndPoints;
+  
+  public ClusterConfiguration(final long configVersion, final List<NodeEndPoint> cacheNodeEndPoints){
+    this.configVersion = configVersion;
+    this.cacheNodeEndPoints = cacheNodeEndPoints;
+  }
+  
+  public long getConfigVersion() {
+    return configVersion;
+  }
+
+  public List<NodeEndPoint> getCacheNodeEndPoints() {
+    return cacheNodeEndPoints;
+  }
+  
+  public List<InetSocketAddress> getInetSocketAddresses(){
+    List<InetSocketAddress> addrs = new ArrayList<InetSocketAddress>(cacheNodeEndPoints.size());
+    for(NodeEndPoint endPoint : cacheNodeEndPoints){
+      addrs.add(endPoint.getInetSocketAddress());
+    }
+    
+    return addrs;
+  }
+  
+  @Override
+  public String toString(){
+    StringBuilder nodeList = new StringBuilder("Version:" + configVersion + "  CacheNode List:");
+    for(NodeEndPoint endPoint : cacheNodeEndPoints){
+      nodeList.append(" " + endPoint.getHostName() + ":" + endPoint.getPort());
+    }
+    
+    return nodeList.toString();
+  }
+}

--- a/src/main/java/net/spy/memcached/config/ClusterConfigurationObserver.java
+++ b/src/main/java/net/spy/memcached/config/ClusterConfigurationObserver.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.config;
+
+/**
+ * Observer for changes in the ConfigurationType.CLUSTER type of config in the cluster.
+ *
+ */
+public interface ClusterConfigurationObserver extends ConfigurationObserver {
+  
+  /**
+   * The publisher calls all the subscribers through this method. This is invoked whenever
+   * there is change in cluster configuration data.
+   * @param clusterConfiguration - The parameter contains the latest information about the cluster. 
+   */
+  public void notifyUpdate(ClusterConfiguration clusterConfiguration);
+
+}

--- a/src/main/java/net/spy/memcached/config/ConfigurationObserver.java
+++ b/src/main/java/net/spy/memcached/config/ConfigurationObserver.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.config;
+
+/**
+ * Base interface for all observers. This is independent of the configuration types. 
+ *
+ */
+public abstract interface ConfigurationObserver {
+
+}

--- a/src/main/java/net/spy/memcached/config/NodeEndPoint.java
+++ b/src/main/java/net/spy/memcached/config/NodeEndPoint.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.config;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+/**
+ * NodeEndPoint captures the information needed to connect to a cache node.
+ * Both hostName and ipAddress to capture the latest information instead of relying entirely on the DNS servers.
+ *
+ */
+public class NodeEndPoint {
+  private final String hostName;
+  private final String ipAddress;
+  private final int port;
+
+  /**
+   * Immutable instance with a hostname, ip address, and port.
+   * 
+   * @param hostName
+   *            hostname (ex. foo.bar.com)
+   * @param ipAddress
+   *            string form of IP address (ex. 10.10.1.1). It is expected that
+   *            this IP address is valid.
+   * @param port
+   *            port (ex. 11211)
+   */
+  public NodeEndPoint(final String hostName, final String ipAddress, final int port) {
+      this.hostName = hostName != null ? hostName.trim() : null;
+      this.ipAddress = ipAddress != null ? ipAddress.trim() : null;
+      this.port = port;
+  }
+
+  /**
+   * Immutable instance, without an IP address.
+   * 
+   * @param hostName
+   *            hostname (ex. foo.bar.com).
+   * @param port
+   *            port (ex. 11211)
+   */
+  public NodeEndPoint(final String hostName, final int port) {
+    this(hostName, null, port);
+  }
+
+  /**
+   * @return hostname (ex. foo.bar.com)
+   */
+  public String getHostName() {
+      return hostName;
+  }
+
+  /**
+   * @return IP address, in textual form (ex. 10.1.10.1)
+   */
+  public String getIpAddress() {
+      return ipAddress;
+  }
+
+  /**
+   * @return port (ex. 11211)
+   */
+  public int getPort() {
+      return port;
+  }
+
+  public InetSocketAddress getInetSocketAddress(){
+	  return getInetSocketAddress(false);
+  }
+  
+  public InetSocketAddress getInetSocketAddress(boolean reresolve){
+    if(reresolve == true || ipAddress == null || ipAddress.trim().equals("")){
+      return new InetSocketAddress(hostName, port);
+    } else {
+      try {
+        return new InetSocketAddress(InetAddress.getByName(ipAddress) , port);
+      } catch (UnknownHostException e) {
+        throw new IllegalArgumentException("Invalid server with hostName:" + hostName + ", IpAddress:" + ipAddress);
+      }
+    }
+  }
+  
+  /**
+   * copy one object to another.
+   */
+  public static NodeEndPoint copy(final NodeEndPoint other) {
+      return new NodeEndPoint(other.getHostName(), other.getIpAddress(), other.getPort());
+  }
+  
+  @Override
+  public String toString(){
+    StringBuilder buffer = new StringBuilder("NodeEndPoint - ");
+    buffer.append("HostName:" + hostName);
+    buffer.append(" IpAddress:" + ipAddress);
+    buffer.append(" Port:" + port);
+    
+    return buffer.toString();
+  }
+
+}

--- a/src/main/java/net/spy/memcached/internal/GetConfigFuture.java
+++ b/src/main/java/net/spy/memcached/internal/GetConfigFuture.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.internal;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.Operation;
+import net.spy.memcached.ops.OperationStatus;
+
+/**
+ * Future returned for GetConfig operation.
+ *
+ * Not intended for general use.
+ *
+ * @param <T> Type of object returned from the getconfig
+ */
+public class GetConfigFuture<T> implements Future<T> {
+
+  private final OperationFuture<Future<T>> rv;
+
+  public GetConfigFuture(CountDownLatch l, long opTimeout, ConfigurationType type) {
+    this.rv = new OperationFuture<Future<T>>(type.getValue(), l, opTimeout);
+  }
+
+  public boolean cancel(boolean ign) {
+    return rv.cancel(ign);
+  }
+
+  public T get() throws InterruptedException, ExecutionException {
+    Future<T> v = rv.get();
+    return v == null ? null : v.get();
+  }
+
+  public T get(long duration, TimeUnit units) throws InterruptedException,
+      TimeoutException, ExecutionException {
+    Future<T> v = rv.get(duration, units);
+    return v == null ? null : v.get();
+  }
+
+  public OperationStatus getStatus() {
+    return rv.getStatus();
+  }
+
+  public void set(Future<T> d, OperationStatus s) {
+    rv.set(d, s);
+  }
+
+  public void setOperation(Operation to) {
+    rv.setOperation(to);
+  }
+
+  public boolean isCancelled() {
+    return rv.isCancelled();
+  }
+
+  public boolean isDone() {
+    return rv.isDone();
+  }
+}

--- a/src/main/java/net/spy/memcached/ops/ConfigurationType.java
+++ b/src/main/java/net/spy/memcached/ops/ConfigurationType.java
@@ -1,0 +1,26 @@
+package net.spy.memcached.ops;
+
+/**
+ * Enumeration for the types of config stored in the cache server.
+ * If the config API is not supported in the cache server, the configuration is stored in 
+ * the key space with a "AmazonElastiCache:" prefix.
+ *
+ */
+public enum ConfigurationType {
+  
+  CLUSTER("cluster");
+  
+  private static final String NAMESPACE = "AmazonElastiCache:";
+  private String value;
+  private ConfigurationType(String value) {
+    this.value = value;
+  }
+  
+  public String getValue(){
+    return value;
+  }
+  
+  public String getValueWithNameSpace(){
+    return NAMESPACE + value;
+  }
+}

--- a/src/main/java/net/spy/memcached/ops/DeleteConfigOperation.java
+++ b/src/main/java/net/spy/memcached/ops/DeleteConfigOperation.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.ops;
+
+/**
+ * Deletion operation for config.
+ */
+public interface DeleteConfigOperation extends Operation {
+  /**
+   * Get the type to be deleted. 
+   */
+  ConfigurationType getType();
+}

--- a/src/main/java/net/spy/memcached/ops/GetConfigOperation.java
+++ b/src/main/java/net/spy/memcached/ops/GetConfigOperation.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.ops;
+
+
+/**
+ * "config get" Operation.
+ */
+public interface GetConfigOperation extends Operation {
+
+  /**
+   * Get the type used for fetching config. 
+   */
+  ConfigurationType getType();
+  
+  /**
+   * Operation callback for the getConfig request.
+   */
+  interface Callback extends OperationCallback {
+    /**
+     * Callback for result from getConfig.
+     *
+     * @param type the type that was retrieved
+     * @param flags the flags for this value
+     * @param data the data stored under this type
+     */
+    void gotData(ConfigurationType type, int flags, byte[] data);
+  }
+}

--- a/src/main/java/net/spy/memcached/ops/SetConfigOperation.java
+++ b/src/main/java/net/spy/memcached/ops/SetConfigOperation.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.ops;
+
+/**
+ * Operation that represents config set.
+ */
+public interface SetConfigOperation extends Operation {
+
+  /**
+   * Get the type used for setting the config.
+   */
+  ConfigurationType getType();
+  
+  /**
+   * Get the flags to be set.
+   */
+  int getFlags();
+
+  /**
+   * Get the bytes to be set during this operation.
+   *
+   * <p>
+   * Note, this returns an exact reference to the bytes and the data
+   * <em>must not</em> be modified.
+   * </p>
+   */
+  byte[] getData();
+}

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -19,6 +19,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached.protocol;
@@ -37,6 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.compat.SpyObject;
+import net.spy.memcached.config.NodeEndPoint;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.protocol.binary.TapAckOperationImpl;
@@ -48,7 +60,8 @@ import net.spy.memcached.protocol.binary.TapAckOperationImpl;
 public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     MemcachedNode {
 
-  private final SocketAddress socketAddress;
+  private NodeEndPoint nodeEndPoint;
+  private SocketAddress socketAddress;
   private final ByteBuffer rbuf;
   private final ByteBuffer wbuf;
   protected final BlockingQueue<Operation> writeQ;
@@ -75,12 +88,14 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
       BlockingQueue<Operation> iq, long opQueueMaxBlockTime,
       boolean waitForAuth, long dt) {
     super();
+
     assert sa != null : "No SocketAddress";
     assert c != null : "No SocketChannel";
     assert bufSize > 0 : "Invalid buffer size: " + bufSize;
     assert rq != null : "No operation read queue";
     assert wq != null : "No operation write queue";
     assert iq != null : "No input queue";
+    
     socketAddress = sa;
     setChannel(c);
     // Since these buffers are allocated rarely (only on client creation
@@ -411,6 +426,24 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
    */
   public final SocketAddress getSocketAddress() {
     return socketAddress;
+  }
+  
+  /*
+   * (non-Javadoc)
+   *
+   * @see net.spy.memcached.MemcachedNode#getNodeEndPoint()
+   */
+  public final NodeEndPoint getNodeEndPoint() {
+    return nodeEndPoint;
+  }
+
+  /**
+   * 
+   * @param nodeEndPoint
+   */
+  public void setNodeEndPoint(NodeEndPoint nodeEndPoint){
+    this.nodeEndPoint = nodeEndPoint;
+    this.socketAddress = nodeEndPoint.getInetSocketAddress();
   }
 
   /*

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -19,6 +19,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached.protocol.ascii;
@@ -33,9 +44,12 @@ import net.spy.memcached.ops.BaseOperationFactory;
 import net.spy.memcached.ops.CASOperation;
 import net.spy.memcached.ops.ConcatenationOperation;
 import net.spy.memcached.ops.ConcatenationType;
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.DeleteConfigOperation;
 import net.spy.memcached.ops.DeleteOperation;
 import net.spy.memcached.ops.FlushOperation;
 import net.spy.memcached.ops.GetAndTouchOperation;
+import net.spy.memcached.ops.GetConfigOperation;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.GetlOperation;
 import net.spy.memcached.ops.GetsOperation;
@@ -46,10 +60,10 @@ import net.spy.memcached.ops.MutatorOperation;
 import net.spy.memcached.ops.NoopOperation;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
-
 import net.spy.memcached.ops.SASLAuthOperation;
 import net.spy.memcached.ops.SASLMechsOperation;
 import net.spy.memcached.ops.SASLStepOperation;
+import net.spy.memcached.ops.SetConfigOperation;
 import net.spy.memcached.ops.StatsOperation;
 import net.spy.memcached.ops.StoreOperation;
 import net.spy.memcached.ops.StoreType;
@@ -97,6 +111,18 @@ public class AsciiOperationFactory extends BaseOperationFactory {
 
   public GetsOperation gets(String key, GetsOperation.Callback cb) {
     return new GetsOperationImpl(key, cb);
+  }
+
+  public GetConfigOperation getConfig(ConfigurationType type, GetConfigOperation.Callback cb) {
+    return new GetConfigOperationImpl(type, cb);
+  }
+  
+  public SetConfigOperation setConfig(ConfigurationType type, int flags, byte[] data, OperationCallback cb){
+    return new SetConfigOperationImpl(type, flags, data, cb);
+  }
+
+  public DeleteConfigOperation deleteConfig(ConfigurationType type, OperationCallback cb) {
+    return new DeleteConfigOperationImpl(type, cb);
   }
 
   public MutatorOperation mutate(Mutator m, String key, long by, long exp,
@@ -191,4 +217,5 @@ public class AsciiOperationFactory extends BaseOperationFactory {
     throw new UnsupportedOperationException("Tap is not supported for ASCII"
         + " protocol");
   }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetConfigOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetConfigOperationImpl.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.protocol.ascii;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Collections;
+
+import net.spy.memcached.ConfigurationTypeUtil;
+import net.spy.memcached.KeyUtil;
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.GetAndTouchOperation;
+import net.spy.memcached.ops.GetConfigOperation;
+import net.spy.memcached.ops.GetOperation;
+import net.spy.memcached.ops.GetlOperation;
+import net.spy.memcached.ops.GetsOperation;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationState;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.util.StringUtils;
+
+/**
+ * Base class for getConfig handlers.
+ */
+abstract class BaseGetConfigOperationImpl extends OperationImpl {
+
+  private static final OperationStatus END = new OperationStatus(true, "END");
+  private static final OperationStatus NOT_FOUND = new OperationStatus(false,
+      "NOT_FOUND");
+  private static final OperationStatus LOCK_ERROR = new OperationStatus(false,
+      "LOCK_ERROR");
+  private static final byte[] RN_BYTES = "\r\n".getBytes();
+  private final String cmd;
+  protected final Collection<ConfigurationType> types;
+  private String currentType = null;
+  private final int exp;
+  private final boolean hasExp;
+  private int currentFlags = 0;
+  private byte[] data = null;
+  private int readOffset = 0;
+  private boolean hasValue;
+
+  /*
+   * Enum to track the state transition while reading off the buffers. Tracking each state
+   *  is critical as the entire response might span multiple buffer reads. 
+   */
+  private enum BufferState{ 
+    READ_CONFIG('*'),
+    RESPONSE_END_START('\r'),
+    RESPONSE_END_FINISH('\n'),
+    READ_COMPLETED('\0');
+    
+    //The value mapping to the enum is used sometimes to help in state transition.
+    private byte value;
+    
+    BufferState(char value){
+      this.value = (byte)value;
+    }
+    
+    public byte getValue(){
+      return value;
+    }
+    
+  }
+  private BufferState lookingFor = BufferState.READ_CONFIG;
+  
+  public BaseGetConfigOperationImpl(String cmd, OperationCallback cb, Collection<ConfigurationType> types) {
+    super(cb);
+    this.cmd = cmd;
+    this.types = types;
+    this.exp = 0;
+    this.hasExp = false;
+    this.hasValue = false;
+  }
+
+  public BaseGetConfigOperationImpl(String cmd, int e, OperationCallback cb, ConfigurationType type) {
+    super(cb);
+    this.cmd = cmd;
+    this.types = Collections.singleton(type);
+    this.exp = e;
+    this.hasExp = true;
+    this.hasValue = false;
+  }
+
+  /**
+   * Get the types that this GetConfigOperation is looking for.
+   */
+  public final Collection<ConfigurationType> getTypes() {
+    return Collections.unmodifiableCollection(types);
+  }
+
+  @Override
+  public final void handleLine(String line) {
+    if (line.equals("END")) {
+      getLogger().debug("Get complete!");
+      if (this.hasValue) {
+        getCallback().receivedStatus(END);
+      } else {
+        getCallback().receivedStatus(NOT_FOUND);
+      }
+      transitionState(OperationState.COMPLETE);
+      data = null;
+    } else if (line.startsWith("CONFIG ")) {
+      getLogger().debug("Got line %s", line);
+      String[] configPreamble = line.split(" ");
+      assert configPreamble[0].equals("CONFIG");
+      this.currentType = configPreamble[1];
+      this.currentFlags = Integer.parseInt(configPreamble[2]);
+      this.data = new byte[Integer.parseInt(configPreamble[3])];
+      this.readOffset = 0;
+      this.hasValue = true;
+      getLogger().debug("Set read type to data");
+      setReadType(OperationReadType.DATA);
+    } else {
+      assert false : "Unknown line type: " + line;
+    }
+  }
+
+  @Override
+  public final void handleRead(ByteBuffer readBuffer) {
+    assert this.currentType != null;
+    assert this.data != null;
+    // This will be the case, because we'll clear them when it's not.
+    assert this.readOffset <= this.data.length : "readOffset is " + this.readOffset
+        + " data.length is " + this.data.length;
+
+    getLogger().debug("readOffset: %d, length: %d", this.readOffset, this.data.length);
+    // If we're not looking for termination, we're still looking for data
+    if (this.lookingFor == BufferState.READ_CONFIG) {
+      transferFromBuffer(readBuffer);
+    }
+    
+    // Transition us into a ``looking for \r\n'' kind of state if we've
+    // read enough and are still in a data state.
+    if (this.readOffset == this.data.length && this.lookingFor == BufferState.READ_CONFIG) {
+      updateCallBackWithResponse();
+      this.lookingFor = BufferState.RESPONSE_END_START;
+    }
+    
+    // If we're looking for an ending byte, let's go find it.
+    if (this.lookingFor != BufferState.READ_CONFIG && readBuffer.hasRemaining()) {
+      readResponseEnding(readBuffer);
+      // Completed the read, reset stuff.
+      if (this.lookingFor == BufferState.READ_COMPLETED) {
+        resetAndChangeReadTypeToLine();
+      }
+    }
+  }
+
+  void transferFromBuffer(ByteBuffer readBuffer){
+    int toRead = this.data.length - this.readOffset;
+    int available = readBuffer.remaining();
+    toRead = Math.min(toRead, available);
+    getLogger().debug("Reading %d bytes", toRead);
+    readBuffer.get(this.data, this.readOffset, toRead);
+    this.readOffset += toRead;    
+  }
+  
+  void updateCallBackWithResponse(){
+    OperationCallback cb = getCallback();
+    if (cb instanceof GetConfigOperation.Callback) {
+      GetConfigOperation.Callback gcb = (GetConfigOperation.Callback) cb;
+      gcb.gotData(ConfigurationType.valueOf(this.currentType.toUpperCase()), this.currentFlags, this.data);
+    } else {
+      throw new ClassCastException("Couldn't convert " + cb
+          + "to a relevent op");
+    }
+  }
+  
+  void readResponseEnding(ByteBuffer readBuffer){
+    do {
+      byte tmp = readBuffer.get();
+      assert tmp == this.lookingFor.getValue() : "Expecting " + this.lookingFor.getValue() + ", got "
+          + (char) tmp;
+      switch (this.lookingFor) {
+      case RESPONSE_END_START:
+        this.lookingFor = BufferState.RESPONSE_END_FINISH;
+        break;
+      case RESPONSE_END_FINISH:
+        this.lookingFor = BufferState.READ_COMPLETED;
+        break;
+      default:
+        assert false : "Looking for unexpected char: " + (char) this.lookingFor.getValue();
+      }
+    } while (this.lookingFor != BufferState.READ_COMPLETED && readBuffer.hasRemaining());    
+  }
+  
+  void resetAndChangeReadTypeToLine(){
+    this.currentType = null;
+    this.data = null;
+    this.lookingFor = BufferState.READ_CONFIG;
+    this.readOffset = 0;
+    this.currentFlags = 0;
+    getLogger().debug("Setting read type back to line.");
+    setReadType(OperationReadType.LINE);
+  }
+
+  @Override
+  public final void initialize() {
+    // Figure out the length of the request
+    int size = 12; // Enough for config get\r\n
+    Collection<byte[]> typeBytes = ConfigurationTypeUtil.getTypeBytes(this.types);
+    for (byte[] t : typeBytes) {
+      size += t.length;
+      //Increment one more for the space after type.
+      size++;
+    }
+    byte[] e = String.valueOf(this.exp).getBytes();
+    if (this.hasExp) {
+      size += e.length + 1;
+    }
+    ByteBuffer b = ByteBuffer.allocate(size);
+    b.put(this.cmd.getBytes());
+    for (byte[] t : typeBytes) {
+      b.put((byte) ' ');
+      b.put(t);
+    }
+    if (this.hasExp) {
+      b.put((byte) ' ');
+      b.put(e);
+    }
+    b.put(RN_BYTES);
+    b.flip();
+    setBuffer(b);
+  }
+
+  @Override
+  protected final void wasCancelled() {
+    getCallback().receivedStatus(CANCELLED);
+  }
+
+  @Override
+  public String toString() {
+    StringBuffer typeValues = new StringBuffer();
+    for(ConfigurationType type : types){
+      typeValues.append(" " + type.getValue());
+    }
+    
+    return "Cmd: " + cmd + " Types: " + typeValues.toString() + "Exp: "
+      + exp;
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteConfigOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteConfigOperationImpl.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.protocol.ascii;
+
+import java.nio.ByteBuffer;
+
+import net.spy.memcached.KeyUtil;
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.DeleteConfigOperation;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationState;
+import net.spy.memcached.ops.OperationStatus;
+
+/**
+ * Operation to delete the specified config types from the cache node.
+ */
+final class DeleteConfigOperationImpl extends OperationImpl implements
+    DeleteConfigOperation {
+
+  private static final String CMD = "config delete";
+  private static final int OVERHEAD = 32;
+
+  private static final OperationStatus DELETED = new OperationStatus(true,
+      "DELETED");
+  private static final OperationStatus NOT_FOUND = new OperationStatus(false,
+      "NOT_FOUND");
+
+  private final ConfigurationType type;
+
+  public DeleteConfigOperationImpl(ConfigurationType type, OperationCallback cb) {
+    super(cb);
+    this.type = type;
+  }
+
+  @Override
+  public void handleLine(String line) {
+    getLogger().debug("Delete of %s returned %s", type, line);
+    getCallback().receivedStatus(matchStatus(line, DELETED, NOT_FOUND));
+    transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public void initialize() {
+    ByteBuffer b = ByteBuffer.allocate(KeyUtil.getKeyBytes(type.getValue()).length
+        + OVERHEAD);
+    setArguments(b, CMD, type.getValue());
+    b.flip();
+    setBuffer(b);
+  }
+
+  @Override
+  public ConfigurationType getType() {
+    return type;
+  }
+  
+  @Override
+  public String toString() {
+    return "Cmd: delete config type: " + type;
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetConfigOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetConfigOperationImpl.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.protocol.ascii;
+
+import java.util.Collections;
+
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.GetConfigOperation;
+
+/**
+ * Operation for retrieving configuration data.
+ */
+class GetConfigOperationImpl extends BaseGetConfigOperationImpl implements GetConfigOperation {
+
+  private static final String CMD = "config get";
+  
+  public GetConfigOperationImpl(ConfigurationType type, GetConfigOperation.Callback c) {
+    super(CMD, c, Collections.singleton(type));
+  }
+
+  @Override
+  public ConfigurationType getType() {
+    return types.iterator().next();
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetConfigOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetConfigOperationImpl.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.protocol.ascii;
+
+import java.nio.ByteBuffer;
+
+import net.spy.memcached.KeyUtil;
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationState;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.SetConfigOperation;
+
+/**
+ * class for ascii config set operations
+ */
+class SetConfigOperationImpl extends OperationImpl implements SetConfigOperation{
+
+  private static final String CMD = "config set";
+  private static final int OVERHEAD = 32;
+  private static final OperationStatus STORED = new OperationStatus(true,
+      "STORED");
+  protected final ConfigurationType type;
+  protected final int flags;
+  protected final byte[] data;
+
+  public SetConfigOperationImpl(ConfigurationType type, int f, byte[] d,
+      OperationCallback cb) {
+    super(cb);
+    this.type = type;
+    flags = f;
+    data = d;
+  }
+
+  @Override
+  public void handleLine(String line) {
+    assert getState() == OperationState.READING : "Read ``" + line
+        + "'' when in " + getState() + " state";
+    getCallback().receivedStatus(matchStatus(line, STORED));
+    transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public void initialize() {
+    ByteBuffer bb = ByteBuffer.allocate(data.length
+        + KeyUtil.getKeyBytes(type.getValue()).length + OVERHEAD);
+    setArguments(bb, CMD, type.getValue(), flags, data.length);
+    assert bb.remaining() >= data.length + 2 : "Not enough room in buffer,"
+        + " need another " + (2 + data.length - bb.remaining());
+    bb.put(data);
+    bb.put(CRLF);
+    bb.flip();
+    setBuffer(bb);
+  }
+
+  @Override
+  protected void wasCancelled() {
+    getCallback().receivedStatus(CANCELLED);
+  }
+
+  public int getFlags() {
+    return flags;
+  }
+
+  public byte[] getData() {
+    return data;
+  }
+
+  @Override
+  public ConfigurationType getType() {
+    return type;
+  }
+  
+  @Override
+  public String toString() {
+    return "Cmd: " + "config set Type: " + type.getValue() + " Flags: " + flags + " Data Length: " + data.length;
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -19,6 +19,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached.protocol.binary;
@@ -33,11 +44,14 @@ import net.spy.memcached.ops.BaseOperationFactory;
 import net.spy.memcached.ops.CASOperation;
 import net.spy.memcached.ops.ConcatenationOperation;
 import net.spy.memcached.ops.ConcatenationType;
+import net.spy.memcached.ops.ConfigurationType;
 import net.spy.memcached.ops.DeleteOperation;
 import net.spy.memcached.ops.FlushOperation;
 import net.spy.memcached.ops.GetAndTouchOperation;
+import net.spy.memcached.ops.GetConfigOperation;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.GetOperation.Callback;
+import net.spy.memcached.ops.DeleteConfigOperation;
 import net.spy.memcached.ops.GetlOperation;
 import net.spy.memcached.ops.GetsOperation;
 import net.spy.memcached.ops.KeyedOperation;
@@ -51,6 +65,7 @@ import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.SASLAuthOperation;
 import net.spy.memcached.ops.SASLMechsOperation;
 import net.spy.memcached.ops.SASLStepOperation;
+import net.spy.memcached.ops.SetConfigOperation;
 import net.spy.memcached.ops.StatsOperation;
 import net.spy.memcached.ops.StoreOperation;
 import net.spy.memcached.ops.StoreType;
@@ -97,6 +112,18 @@ public class BinaryOperationFactory extends BaseOperationFactory {
 
   public GetsOperation gets(String key, GetsOperation.Callback cb) {
     return new GetsOperationImpl(key, cb);
+  }
+
+  public GetConfigOperation getConfig(ConfigurationType type, GetConfigOperation.Callback callback) {
+    return new GetConfigOperationImpl(type, callback);
+  }
+  
+  public SetConfigOperation setConfig(ConfigurationType type, int flags, byte[] data, OperationCallback cb){
+    return new SetConfigOperationImpl(type, flags, data, cb);
+  }
+  
+  public DeleteConfigOperation deleteConfig(ConfigurationType type, OperationCallback cb) {
+    return new DeleteConfigOperationImpl(type, cb);
   }
 
   public MutatorOperation mutate(Mutator m, String key, long by, long def,

--- a/src/main/java/net/spy/memcached/protocol/binary/DeleteConfigOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/DeleteConfigOperationImpl.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.protocol.binary;
+
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.DeleteConfigOperation;
+import net.spy.memcached.ops.OperationCallback;
+
+/**
+ * Binary protocol implementation for config delete.
+ * 
+ */
+class DeleteConfigOperationImpl extends OperationImpl implements
+    DeleteConfigOperation {
+
+  private static final byte CMD = 0x66;
+  private final ConfigurationType type;
+  
+  public DeleteConfigOperationImpl(ConfigurationType type, OperationCallback cb) {
+    super(CMD, generateOpaque(), cb);
+    this.type = type;
+  }
+
+  @Override
+  public void initialize() {
+    prepareBuffer(type.getValue(), 0, EMPTY_BYTES);
+  }
+  
+  @Override
+  public ConfigurationType getType() {
+    return type;
+  }
+
+  @Override
+  public String toString() {
+    return super.toString() + " Type: " + type;
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/binary/GetConfigOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/GetConfigOperationImpl.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.protocol.binary;
+
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.GetConfigOperation;
+
+/**
+ * Binary protocol implementation for "config get <key>".
+ * 
+ */
+class GetConfigOperationImpl extends OperationImpl implements GetConfigOperation {
+
+  protected final ConfigurationType type;
+  
+  static final byte CONFIG_GET_CMD = 0x60;
+
+  /**
+   * Length of the extra header stuff for a GET CONFIG response.
+   * 4 bytes is used for flags.
+   */
+  static final int EXTRA_HDR_LEN = 4;
+
+  public GetConfigOperationImpl(ConfigurationType type, GetConfigOperation.Callback cb) {
+    super(CONFIG_GET_CMD, generateOpaque(), cb);
+    this.type = type;
+  }
+
+  @Override
+  public void initialize() {
+    prepareBuffer(type.getValue(), 0, EMPTY_BYTES);
+  }
+
+  @Override
+  protected void decodePayload(byte[] pl) {
+    final int flags = decodeInt(pl, 0);
+    final byte[] data = new byte[pl.length - EXTRA_HDR_LEN];
+    System.arraycopy(pl, EXTRA_HDR_LEN, data, 0, pl.length - EXTRA_HDR_LEN);
+    GetConfigOperation.Callback gcb = (GetConfigOperation.Callback) getCallback();
+    gcb.gotData(type, flags, data);
+    getCallback().receivedStatus(STATUS_OK);
+  }
+
+  @Override
+  public ConfigurationType getType() {
+    return type;
+  }
+
+  @Override
+  public String toString() {
+    return super.toString() + " Type: " + type.getValue();
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/binary/SetConfigOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SetConfigOperationImpl.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+ *
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package net.spy.memcached.protocol.binary;
+
+import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.SetConfigOperation;
+
+/**
+ * Binary protocol implementation for "config set".
+ * 
+ */
+class SetConfigOperationImpl extends OperationImpl implements
+    SetConfigOperation{
+
+  private static final byte SET_CONFIG = 0x64;
+
+  private final ConfigurationType type;
+  private final int flags;
+  private final byte[] data;
+
+  public SetConfigOperationImpl(ConfigurationType type, int f, byte[] d, OperationCallback cb) {
+    super(SET_CONFIG, generateOpaque(), cb);
+    this.type = type;
+    flags = f;
+    data = d;
+  }
+
+  @Override
+  public void initialize() {
+    prepareBuffer(type.getValue(), 0, data, flags);
+  }
+
+  public int getFlags() {
+    return flags;
+  }
+
+  public byte[] getData() {
+    return data;
+  }
+
+  @Override
+  public ConfigurationType getType() {
+    return type;
+  }
+  
+  @Override
+  public String toString() {
+    return super.toString() + " Type: " + type + " Flags: " + flags + " Data Length: " + data.length;
+  }
+}

--- a/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
@@ -19,6 +19,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached;
@@ -41,7 +52,7 @@ public class ConnectionFactoryTest extends TestCase {
   }
 
   public void testBinaryAnIntAnotherIntAndAHashAlgorithmCons() {
-    new BinaryConnectionFactory(5, 5, DefaultHashAlgorithm.FNV1_64_HASH);
+    new BinaryConnectionFactory(ClientMode.Static, 5, 5, DefaultHashAlgorithm.FNV1_64_HASH);
   }
 
   public void testQueueSizes() {

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -19,6 +19,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached;
@@ -31,6 +42,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
 
+import net.spy.memcached.config.NodeEndPoint;
 import net.spy.memcached.ops.Operation;
 
 /**
@@ -38,13 +50,27 @@ import net.spy.memcached.ops.Operation;
  */
 public class MockMemcachedNode implements MemcachedNode {
   private final InetSocketAddress socketAddress;
-
+  private NodeEndPoint nodeEndPoint;
+  
   public SocketAddress getSocketAddress() {
     return socketAddress;
   }
-
+  
+  public NodeEndPoint getNodeEndPoint(){
+    return nodeEndPoint;
+  }
+  
+  public void setNodeEndPoint(NodeEndPoint nodeEndPoint){
+    this.nodeEndPoint = nodeEndPoint;
+  }
+  
   public MockMemcachedNode(InetSocketAddress socketAddress) {
     this.socketAddress = socketAddress;
+  }
+  
+  public MockMemcachedNode(NodeEndPoint nodeEndPoint) {
+    this.nodeEndPoint = nodeEndPoint;
+    this.socketAddress = nodeEndPoint.getInetSocketAddress();
   }
 
   @Override

--- a/src/test/java/net/spy/memcached/ToStringTest.java
+++ b/src/test/java/net/spy/memcached/ToStringTest.java
@@ -18,6 +18,17 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
  * IN THE SOFTWARE.
+ * 
+ * 
+ * Portions Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Amazon Software License (the "License"). You may not use this 
+ * file except in compliance with the License. A copy of the License is located at
+ *  http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+ * implied. See the License for the specific language governing permissions and 
+ * limitations under the License.
  */
 
 package net.spy.memcached;
@@ -34,14 +45,14 @@ public class ToStringTest extends TestCase {
   public void testDefaultConnectionFactory() {
     (new DefaultConnectionFactory()).toString();
     (new DefaultConnectionFactory(10, 1000)).toString();
-    (new DefaultConnectionFactory(100, 100,
+    (new DefaultConnectionFactory(ClientMode.Dynamic, 100, 100,
         DefaultHashAlgorithm.KETAMA_HASH)).toString();
   }
 
   public void testBinaryConnectionFactory() {
     (new BinaryConnectionFactory()).toString();
     (new BinaryConnectionFactory(10, 1000)).toString();
-    (new BinaryConnectionFactory(100, 1000,
+    (new BinaryConnectionFactory(ClientMode.Dynamic, 100, 1000,
         DefaultHashAlgorithm.KETAMA_HASH)).toString();
   }
 }

--- a/xdocs/index.xml
+++ b/xdocs/index.xml
@@ -1,20 +1,22 @@
 <?xml version="1.0"?>
 
-<!-- Copyright (c) 2006  Dustin Sallings (dustin@spy.net) -->
+<!-- 
+     Copyright (c) 2006  Dustin Sallings (dustin@spy.net)
+     Copyright (C) 2012-2012 Amazon.com, Inc. or its affiliates.
+-->
 
 <document>
 	<properties>
-		<author email="dustin@spy.net">Dustin Sallings</author>
-		<title>java memcached client</title>
+		<author email="elasticache-forums@amazon.com">Amazon.com, Inc</author>
+		<title>java client for Amazon ElastiCache</title>
 	</properties>
 
 	<body>
 		<section name="Overview">
 			<p>
 				This project is now primarily hosted at
-				<a href="http://code.google.com/p/spymemcached/">google code
-				hosting</a> with the source at <a
-				href="http://github.com/dustin/java-memcached-client">github</a>.
+                                <a href="http://docs.amazonwebservices.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html"> AWS ElastiCache</a> with the source at <a
+                                href="https://github.com/amazonwebservices/aws-elasticache-cluster-client-memcached-for-java">github</a>.
 			</p>
       <p>
         <a href="changelog.html">Changelog</a>


### PR DESCRIPTION
The ConfigurationPoller always created a non-daemon thread. This patch uses
the ConnectionFactory.isDaemon() method to determine how the thread should
be created.
