### PR TITLE
 Support for non-daemon threads in the ConfigurationPoller

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -346,7 +346,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     }
     
     //Initialize and start the poller.
-    configPoller = new ConfigurationPoller(this, cf.getDynamicModePollingInterval());
+    configPoller = new ConfigurationPoller(this, cf.getDynamicModePollingInterval(), cf.isDaemon());
     configPoller.subscribeForClusterConfiguration(mconn);
   }
 


### PR DESCRIPTION
The ConfigurationPoller always created a non-daemon thread. This patch uses
the ConnectionFactory.isDaemon() method to determine how the thread should
be created.

This is an updated version of a pull request that I submitted on May 9, 2013: https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java/pull/1. I never got a response to that PR.