### PR TITLE
Fixing issue where an NPE would occur if a authDescriptor was sent in…

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -290,18 +290,18 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     transcoder = cf.getDefaultTranscoder();
     opFact = cf.getOperationFactory();
     assert opFact != null : "Connection factory failed to make op factory";
-    
+
+    if(clientMode == ClientMode.Dynamic){
+      initializeClientUsingConfigEndPoint(cf, addrs.get(0));
+    } else {
+      setupConnection(cf, addrs);
+    }
+
     operationTimeout = cf.getOperationTimeout();
     authDescriptor = cf.getAuthDescriptor();
     executorService = cf.getListenerExecutorService();
     if (authDescriptor != null) {
       addObserver(this);
-    }
-    
-    if(clientMode == ClientMode.Dynamic){
-      initializeClientUsingConfigEndPoint(cf, addrs.get(0));
-    } else {
-      setupConnection(cf, addrs);
     }
   }
   


### PR DESCRIPTION
…to the memcached instance, found while trying to implement SASL for customers to have a way to secure their memcached instances.
