### PR TITLE
Add ability for clientMode to be set from Spring bean resource injection

### DIFF
--- a/src/main/java/net/spy/memcached/spring/MemcachedClientFactoryBean.java
+++ b/src/main/java/net/spy/memcached/spring/MemcachedClientFactoryBean.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 import net.spy.memcached.AddrUtil;
+import net.spy.memcached.ClientMode;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.ConnectionFactoryBuilder.Locator;
 import net.spy.memcached.ConnectionFactoryBuilder.Protocol;
@@ -181,6 +182,14 @@ public class MemcachedClientFactoryBean implements FactoryBean,
 
   public void setWriteOpQueueFactory(final OperationQueueFactory q) {
     connectionFactoryBuilder.setWriteOpQueueFactory(q);
+  }
+
+  /**
+   * Set the client mode. Defaults to Dynamic which enables Auto Discovery. Can also be set to Static which turns off
+   * Auto Discovery and has the same functionality as a classic SpyMemcached client.
+   */
+  public void setClientMode(final ClientMode clientMode) {
+    connectionFactoryBuilder.setClientMode(clientMode);
   }
 
   /**


### PR DESCRIPTION
Would like the ability to be able to set the clientMode to Static from Grails (Spring) dependency injection to be able to do something like the following when injecting the memcachedClient resource.

```
memcachedClient(MemcachedClientFactoryBean) {
	clientMode = ClientMode.Static // This is currently being ignored
	protocol = "BINARY"
	opTimeout = 1000
	timeoutExceptionThreshold = 1998
	hashAlg = DefaultHashAlgorithm.KETAMA_HASH
	locatorType = "CONSISTENT"
	failureMode = "Cancel"
	useNagleAlgorithm = false
	transcoder(net.spy.memcached.transcoders.SerializingTranscoder) {
		compressionThreshold = 1024
	}
}
```