### PR TITLE
Bumped Maven version from 1.1.1 to 1.1.2 in the pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws</groupId>
   <artifactId>elasticache-java-cluster-client</artifactId>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <name>ElastiCacheJavaClusterClient</name>
   <description>Amazon ElastiCache Cluster Client is an enhanced Java library to connect to ElastiCache clusters. This client library has been built upon Spymemcached and is released under the Apache 2.0 License.</description>
   <url>https://aws.amazon.com/documentation/elasticache/</url>  


### PR DESCRIPTION
*Description of changes:*

Current release is 1.1.2, but in the pom.xml file we are still using 1.1.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
