### PR TITLE
fix reconnecting issue in TLS mode

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -459,7 +459,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
   public final boolean doTlsHandshake(long timeoutInMillis) throws IOException {
     // Initialize SSLEngine and TLSConnectionHandler for TLS connection
     SSLContext sslContext = connectionFactory.getSSLContext();
-    assert sslContext != null : "Something is wrong with TLS connection mechanism";
+    assert sslContext != null : "SSLContext should be present in connectionFactory for TLS connection";
 
     SSLEngine sslEngine;
     if (!connectionFactory.skipTlsHostnameVerification() && connectionFactory.getHostnameForTlsVerification() == null){
@@ -482,6 +482,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
       // Allocate rbuf and wbuf size for TLS connections
       rbuf = ByteBuffer.allocateDirect(tlsBufSize);
       wbuf = ByteBuffer.allocateDirect(tlsBufSize);
+      bufSize = tlsBufSize;
     }
 
     return tlsConnectionHandler.doTlsHandshake(timeoutInMillis);


### PR DESCRIPTION
*Issue:* In Dynamic mode, when replace a node of a Elasticache cluster, reconnecting mechanism has a bug when begin handshake

*Description of changes:* fix reconnecting issue in TLS mode


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
