### PR TITLE
fix unit test failure in testIPv6Host() by adding valid hostname

### DIFF
--- a/src/test/java/net/spy/memcached/AddrUtilTest.java
+++ b/src/test/java/net/spy/memcached/AddrUtilTest.java
@@ -119,6 +119,7 @@ public class AddrUtilTest extends TestCase {
 
     Set<String> validLocalhostNames = new HashSet<String>();
     validLocalhostNames.add("localhost");
+    validLocalhostNames.add("localhost6");
     validLocalhostNames.add("ip6-localhost");
     validLocalhostNames.add("0:0:0:0:0:0:0:1");
     validLocalhostNames.add("localhost6.localdomain6");


### PR DESCRIPTION
*Issue #, if available:* testIPv6Host() failed depends on machine (passed in MacOS, but failed in AL2)

*Description of changes:*
The ipv6 address can return a hostname `localhost6`, it needs to be added to the list of valid hostnames that can
be returned

*Test:* `ant test` passed in all unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
