### PR TITLE
fix travis-ci build falied

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk8
-  - oraclejdk7
+  - openjdk8
+  - openjdk7


### PR DESCRIPTION
*Issue #, if available:* Travis CI build failed due to Travis CI moves to Xenial from Trusty and oraclejdk8 isn’t supported on Xenial

*Description of changes:* fix travis-ci build falied


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
