### PR TITLE
fix build version through most recent git tag

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -480,6 +480,7 @@
     <exec executable="git" resultproperty="err" outputproperty="result">
       <arg value="describe" />
       <arg value="--abbrev=0" />
+      <arg value="--tags" />
     </exec>
     <if>
       <equals arg1="${err}" arg2="0"/>


### PR DESCRIPTION
*Issue #, if available:* `ant` build doesn't pick up the latest tag.

*Description of changes:* New build jar file will have the name correspondence with the latest release


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
