### PR TITLE
Fix await 50 sec issue during client initialization

### DIFF
--- a/src/main/java/net/spy/memcached/ConfigurationPoller.java
+++ b/src/main/java/net/spy/memcached/ConfigurationPoller.java
@@ -177,6 +177,7 @@ public class ConfigurationPoller extends SpyThread{
           for(ClusterConfigurationObserver observer : clusterConfigObservers){
             getLogger().info("Notifying observers about configuration change.");
             observer.notifyUpdate(newClusterConfiguration);
+            observer.waitForConfigChangeApplied();
           }
           if(!client.isConfigurationInitialized()){
             client.setIsConfigurtionInitialized(true);

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -332,6 +332,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
         
         //Initialize client with the actual set of endpoints.
         mconn.notifyUpdate(clusterConfiguration);
+        mconn.waitForInitialConfigApplied();
         isConfigurationInitialized = true;
       }
     }catch(OperationTimeoutException e){
@@ -348,7 +349,6 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
 
     mconn = cf.createConnection(addrs);
     assert mconn != null : "Connection factory failed to make a connection";
-
   }
   
   public NodeEndPoint getConfigurationNode(){

--- a/src/main/java/net/spy/memcached/config/ClusterConfigurationObserver.java
+++ b/src/main/java/net/spy/memcached/config/ClusterConfigurationObserver.java
@@ -18,4 +18,9 @@ public interface ClusterConfigurationObserver extends ConfigurationObserver {
    */
   public void notifyUpdate(ClusterConfiguration clusterConfiguration);
 
+  /**
+   * Wait for the configuration change applied. This is invoked whenever the observers get notified
+   * except configuration change during the client initialization.
+   */
+  public void waitForConfigChangeApplied();
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There may have a race condition during client initialization time. When the race condition happens, the MemcachedClient thread will need to wait for 50 secs ( defined previously) to move to next step. This commit will prevent this condition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
