### PR TITLE
Handle the UnresolvedAddressException in the createConnections function.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -63,6 +63,7 @@ import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
+import java.nio.channels.UnresolvedAddressException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -491,6 +492,9 @@ public class MemcachedConnection extends SpyThread implements ClusterConfigurati
             : "Not connected, and not wanting to connect";
       } catch (SocketException e) {
         getLogger().warn("Socket error on initial connect", e);
+        queueReconnect(qa);
+      } catch (UnresolvedAddressException e) {
+        getLogger().warn("Unresolved Address error on initial connect", e);
         queueReconnect(qa);
       }
       connections.add(qa);


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This exception can be thrown if the DNS for the configuration endpoint doesn't resolve. It possible that the DNS may take some time to updated and in those situations the UnresolvedAddressException will be thrown on the `ch.connect(sa)` call [line 479](https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java/blob/master/src/main/java/net/spy/memcached/MemcachedConnection.java#L479).

Currently if this exception is thrown the SocketChannel gets leaked because the sockets and never cleaned up after the exception is thrown.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
