### PR TITLE
Ensure that the metrics collectors for MemcachedConnection gets initialized before it is used.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -340,6 +340,10 @@ public class MemcachedConnection extends SpyThread implements ClusterConfigurati
     this.bufSize = bufSize;
     this.connectionFactory = f;
     isInitialClusterConfigApplied = false;
+    metrics = f.getMetricCollector();
+    metricType = f.enableMetrics();
+
+    registerMetrics();
 
     isTlsMode = f.getSSLContext() != null;
 
@@ -369,11 +373,6 @@ public class MemcachedConnection extends SpyThread implements ClusterConfigurati
     
     List<MemcachedNode> connections = createConnections(endPoints);
     locator = f.createLocator(connections);
-
-    metrics = f.getMetricCollector();
-    metricType = f.enableMetrics();
-
-    registerMetrics();
 
     setName("Memcached IO over " + this);
     setDaemon(f.isDaemon());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
It is possible that if an UnresolvedAddressException or a SocketException is [thrown on the initial connect](https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java/blob/master/src/main/java/net/spy/memcached/MemcachedConnection.java#L493) that the [queueReconnect will try to call the metricsCollector](https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java/blob/master/src/main/java/net/spy/memcached/MemcachedConnection.java#L1262) before it's been initialized. Since the metrics collector is initialized after attempting to make this initial connections.

This change fixes this issue by initializing the metrics collector before the connect calls

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
