### PR TITLE
SASL authentication fixes

### DIFF
--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -64,6 +64,7 @@ import net.spy.memcached.tapmessage.RequestMessage;
 import net.spy.memcached.tapmessage.TapOpcode;
 
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslClient;
 import java.util.Collection;
 import java.util.Map;
 
@@ -334,15 +335,12 @@ public interface OperationFactory {
   /**
    * Create a new sasl auth operation.
    */
-  SASLAuthOperation saslAuth(String[] mech, String serverName,
-      Map<String, ?> props, CallbackHandler cbh, OperationCallback cb);
+  SASLAuthOperation saslAuth(SaslClient sc, OperationCallback cb);
 
   /**
    * Create a new sasl step operation.
    */
-  SASLStepOperation saslStep(String[] mech, byte[] challenge,
-      String serverName, Map<String, ?> props, CallbackHandler cbh,
-      OperationCallback cb);
+  SASLStepOperation saslStep(SaslClient sc, byte[] ch, OperationCallback cb);
 
   /**
    * Clone an operation.

--- a/src/main/java/net/spy/memcached/auth/AuthDescriptor.java
+++ b/src/main/java/net/spy/memcached/auth/AuthDescriptor.java
@@ -24,6 +24,8 @@
 package net.spy.memcached.auth;
 
 import javax.security.auth.callback.CallbackHandler;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * Information required to specify authentication mechanisms and callbacks.
@@ -32,6 +34,8 @@ public class AuthDescriptor {
 
   private final String[] mechs;
   private final CallbackHandler cbh;
+  private final Map<String, ?> props;
+  private final String serverName;
   private int authAttempts;
   private int allowedAuthAttempts;
 
@@ -49,12 +53,19 @@ public class AuthDescriptor {
    * should be used instead, passing in new String[] {"PLAIN"} will force
    * the client to use PLAIN.</p>
    *
+   * <p>It is possible to specify an optional server name to be used
+   * in certain digest mechanisms for validation. If unspecified, the server's
+   * socket address is used.</p>
+   *
    * @param m list of mechanisms
    * @param h the callback handler for grabbing credentials and stuff
+   * @param s the server name. Can be null
    */
-  public AuthDescriptor(String[] m, CallbackHandler h) {
+  public AuthDescriptor(String[] m, CallbackHandler h, String s, Map<String, ?> p) {
     mechs = m;
     cbh = h;
+    props = p;
+    serverName = s;
     authAttempts = 0;
     String authThreshhold =
         System.getProperty("net.spy.memcached.auth.AuthThreshold");
@@ -63,6 +74,15 @@ public class AuthDescriptor {
     } else {
       allowedAuthAttempts = -1; // auth forever
     }
+  }
+
+  /**
+   *
+   * @param m list of mechanisms
+   * @param h the callback handler for grabbing credentials and stuff
+   */
+  public AuthDescriptor(String[] m, CallbackHandler h) {
+    this(m, h, null, null);
   }
 
   /**
@@ -96,5 +116,13 @@ public class AuthDescriptor {
 
   public CallbackHandler getCallback() {
     return cbh;
+  }
+
+  public Map<String, ?> getProperties() {
+    return props;
+  }
+
+  public String getServerName() {
+    return serverName;
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -67,6 +67,7 @@ import net.spy.memcached.tapmessage.RequestMessage;
 import net.spy.memcached.tapmessage.TapOpcode;
 
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslClient;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -192,20 +193,20 @@ public class AsciiOperationFactory extends BaseOperationFactory {
     return rv;
   }
 
+  @Override
   public SASLMechsOperation saslMechs(OperationCallback cb) {
     throw new UnsupportedOperationException("SASL is not supported for "
         + "ASCII protocol");
   }
 
-  public SASLStepOperation saslStep(String[] mech, byte[] challenge,
-      String serverName, Map<String, ?> props, CallbackHandler cbh,
-      OperationCallback cb) {
+  @Override
+  public SASLStepOperation saslStep(SaslClient sc, byte[] challenge, OperationCallback cb) {
     throw new UnsupportedOperationException("SASL is not supported for "
         + "ASCII protocol");
   }
 
-  public SASLAuthOperation saslAuth(String[] mech, String serverName,
-      Map<String, ?> props, CallbackHandler cbh, OperationCallback cb) {
+  @Override
+  public SASLAuthOperation saslAuth(SaslClient sc, OperationCallback cb) {
     throw new UnsupportedOperationException("SASL is not supported for "
         + "ASCII protocol");
   }

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -33,13 +33,13 @@ import net.spy.memcached.ops.CASOperation;
 import net.spy.memcached.ops.ConcatenationOperation;
 import net.spy.memcached.ops.ConcatenationType;
 import net.spy.memcached.ops.ConfigurationType;
+import net.spy.memcached.ops.DeleteConfigOperation;
 import net.spy.memcached.ops.DeleteOperation;
 import net.spy.memcached.ops.FlushOperation;
 import net.spy.memcached.ops.GetAndTouchOperation;
 import net.spy.memcached.ops.GetConfigOperation;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.GetOperation.Callback;
-import net.spy.memcached.ops.DeleteConfigOperation;
 import net.spy.memcached.ops.GetlOperation;
 import net.spy.memcached.ops.GetsOperation;
 import net.spy.memcached.ops.KeyedOperation;
@@ -68,10 +68,9 @@ import net.spy.memcached.ops.VersionOperation;
 import net.spy.memcached.tapmessage.RequestMessage;
 import net.spy.memcached.tapmessage.TapOpcode;
 
-import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslClient;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
 
 /**
  * Factory for binary operations.
@@ -217,20 +216,19 @@ public class BinaryOperationFactory extends BaseOperationFactory {
     return rv;
   }
 
-  public SASLAuthOperation saslAuth(String[] mech, String serverName,
-      Map<String, ?> props, CallbackHandler cbh, OperationCallback cb) {
-    return new SASLAuthOperationImpl(mech, serverName, props, cbh, cb);
+  @Override
+  public SASLAuthOperation saslAuth(SaslClient sc, OperationCallback cb) {
+    return new SASLAuthOperationImpl(sc, cb);
   }
 
+  @Override
   public SASLMechsOperation saslMechs(OperationCallback cb) {
     return new SASLMechsOperationImpl(cb);
   }
 
-  public SASLStepOperation saslStep(String[] mech, byte[] challenge,
-      String serverName, Map<String, ?> props, CallbackHandler cbh,
-      OperationCallback cb) {
-    return new SASLStepOperationImpl(mech, challenge, serverName, props, cbh,
-        cb);
+  @Override
+  public SASLStepOperation saslStep(SaslClient sc, byte[] ch, OperationCallback cb) {
+    return new SASLStepOperationImpl(sc, ch, cb);
   }
 
   public TapOperation tapBackfill(String id, long date, OperationCallback cb) {

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLAuthOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLAuthOperationImpl.java
@@ -23,14 +23,11 @@
 
 package net.spy.memcached.protocol.binary;
 
-import java.util.Map;
-
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.sasl.SaslClient;
-import javax.security.sasl.SaslException;
-
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.SASLAuthOperation;
+
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslException;
 
 /**
  * SASL authenticator.
@@ -40,15 +37,13 @@ public class SASLAuthOperationImpl extends SASLBaseOperationImpl implements
 
   private static final byte CMD = 0x21;
 
-  public SASLAuthOperationImpl(String[] m, String s, Map<String, ?> p,
-      CallbackHandler h, OperationCallback c) {
-    super(CMD, m, EMPTY_BYTES, s, p, h, c);
+  public SASLAuthOperationImpl(SaslClient sc, OperationCallback c) {
+    super(CMD, sc, EMPTY_BYTES, c);
   }
 
   @Override
-  protected byte[] buildResponse(SaslClient sc) throws SaslException {
-    return sc.hasInitialResponse() ? sc.evaluateChallenge(challenge)
-        : EMPTY_BYTES;
+  protected byte[] buildResponse() throws SaslException {
+    return sc.hasInitialResponse() ? sc.evaluateChallenge(ch) : ch;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLStepOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLStepOperationImpl.java
@@ -23,14 +23,11 @@
 
 package net.spy.memcached.protocol.binary;
 
-import java.util.Map;
-
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.sasl.SaslClient;
-import javax.security.sasl.SaslException;
-
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.SASLStepOperation;
+
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslException;
 
 /**
  * A SASLStepOperationImpl.
@@ -40,14 +37,13 @@ public class SASLStepOperationImpl extends SASLBaseOperationImpl implements
 
   private static final byte CMD = 0x22;
 
-  public SASLStepOperationImpl(String[] m, byte[] ch, String s,
-      Map<String, ?> p, CallbackHandler h, OperationCallback c) {
-    super(CMD, m, ch, s, p, h, c);
+  public SASLStepOperationImpl(SaslClient sc, byte[] challenge, OperationCallback c) {
+    super(CMD, sc, challenge, c);
   }
 
   @Override
-  protected byte[] buildResponse(SaslClient sc) throws SaslException {
-    return sc.evaluateChallenge(challenge);
+  protected byte[] buildResponse() throws SaslException {
+    return sc.evaluateChallenge(ch);
   }
 
   @Override

--- a/src/test/java/net/spy/memcached/protocol/binary/BinaryToStringTest.java
+++ b/src/test/java/net/spy/memcached/protocol/binary/BinaryToStringTest.java
@@ -88,7 +88,7 @@ public class BinaryToStringTest extends TestCase {
   }
 
   public void testSASLAuth() {
-    (new SASLAuthOperationImpl(null, null, null, null, null)).toString();
+    (new SASLAuthOperationImpl(null, null)).toString();
   }
 
   public void testSASLMechs() {
@@ -96,7 +96,7 @@ public class BinaryToStringTest extends TestCase {
   }
 
   public void testSASLStep() {
-    (new SASLStepOperationImpl(null, null, null, null, null, null)).toString();
+    (new SASLStepOperationImpl(null, null, null)).toString();
   }
 
   public void testStats() {


### PR DESCRIPTION
* Reuse SaslClient across all steps of an authentication
* Allow passing a server name through AuthDescriptor
* Allow passing SASL client properties through AuthDescriptor

