### PR TITLE
Fix a bug in clientMode determination logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws</groupId>
   <artifactId>elasticache-java-cluster-client</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -285,18 +285,18 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     transcoder = cf.getDefaultTranscoder();
     opFact = cf.getOperationFactory();
     assert opFact != null : "Connection factory failed to make op factory";
-
-    if(clientMode == ClientMode.Dynamic){
-      initializeClientUsingConfigEndPoint(cf, addrs.get(0));
-    } else {
-      setupConnection(cf, addrs);
-    }
-
+    
     operationTimeout = cf.getOperationTimeout();
     authDescriptor = cf.getAuthDescriptor();
     executorService = cf.getListenerExecutorService();
     if (authDescriptor != null) {
       addObserver(this);
+    }
+    
+    if(clientMode == ClientMode.Dynamic){
+      initializeClientUsingConfigEndPoint(cf, addrs.get(0));
+    } else {
+      setupConnection(cf, addrs);
     }
   }
 

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -248,6 +248,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     //An internal customer convenience check to determine whether the client mode based on 
     // the DNS name if only one endpoint is specified. 
     if(determineClientMode){
+      boolean isClientModeDetermined = false;
       if(addrs.size() == 1){
         if(addrs.get(0) == null){
           throw new NullPointerException("Socket address is null");
@@ -256,10 +257,14 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
         //All config endpoints has ".cfg." subdomain in the DNS name.
         if(hostName != null && hostName.contains(".cfg.")){
           cf = updateClientMode(cf, ClientMode.Dynamic);
+          isClientModeDetermined = true;
         }
       }
       //Fallback to static mode
-      cf = updateClientMode(cf, ClientMode.Static);
+      if (!isClientModeDetermined) {
+        cf = updateClientMode(cf, ClientMode.Static);
+        isClientModeDetermined = true;
+      }
     }
 
     if (cf == null) {

--- a/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
@@ -73,10 +73,14 @@ public class MemcachedConnectionTest extends TestCase {
     assertTrue(conn.belongsToCluster(node));
     assertFalse(conn.belongsToCluster(node2));
   }
-  public void testDefaultClientMode() throws Exception {
+
+  public void testClientMode() throws Exception {
     ConnectionFactory factory = new DefaultConnectionFactory();
     assert factory.getClientMode() == ClientMode.Unset;
-    MemcachedClient client = new MemcachedClient(factory, AddrUtil.getAddresses(UnitTestConfig.IPV4_ADDR + ":11211"));
-    assert client.clientMode == ClientMode.Static;
+    MemcachedClient client1 = new MemcachedClient(factory, AddrUtil.getAddresses(UnitTestConfig.IPV4_ADDR + ":11211"));
+    assert client1.clientMode == ClientMode.Static;
+    MemcachedClient client2 = new MemcachedClient(AddrUtil.getAddresses(UnitTestConfig.TEST_HOSTNAME + ":11211"));
+    assert client2.clientMode == ClientMode.Dynamic;
   }
+
 }

--- a/src/test/java/net/spy/memcached/UnitTestConfig.java
+++ b/src/test/java/net/spy/memcached/UnitTestConfig.java
@@ -36,6 +36,7 @@ public final class UnitTestConfig {
   public static final String PORT_PROP = "server.port_number";
   public static final String TYPE_TEST_UNIT = "unit";
   public static final String TYPE_TEST_CI = "ci";
+  public static final String TEST_HOSTNAME = "abc.cfg.test.com";
 
   //currently server host address ipv4 is always default to "127.0.0.1", disabled in build.xml
   public static final String IPV4_ADDR = System.getProperty(IPV4_PROP,


### PR DESCRIPTION
- Fix bug in clientMode
- bump client version
- Revert "Fixing issue where an NPE would occur if a authDescriptor was sent into the memcached instance, found while trying to implement SASL for customers to have a way to secure their memcached instances."
