### PR TITLE
Fixing client initialization delay issue due to improper config

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -286,15 +286,16 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     opFact = cf.getOperationFactory();
     assert opFact != null : "Connection factory failed to make op factory";
 
+    operationTimeout = cf.getOperationTimeout();
+    authDescriptor = cf.getAuthDescriptor();
+    executorService = cf.getListenerExecutorService();
+
     if(clientMode == ClientMode.Dynamic){
       initializeClientUsingConfigEndPoint(cf, addrs.get(0));
     } else {
       setupConnection(cf, addrs);
     }
 
-    operationTimeout = cf.getOperationTimeout();
-    authDescriptor = cf.getAuthDescriptor();
-    executorService = cf.getListenerExecutorService();
     if (authDescriptor != null) {
       addObserver(this);
     }


### PR DESCRIPTION
### Issue
In this logic: https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java/blob/master/src/main/java/net/spy/memcached/MemcachedClient.java#L289-L297

ExecutorService initialized after`initializeClientUsingConfigEndPoint(cf, addrs.get(0));`call,  so the config get call in  `initializeClientUsingConfigEndPoint()` run into error and throws exceptions, which lead to delay time in client initialization ( around 5 secs) 

### Test
Passed functional test against non-tls cluster and tls cluster and unit tests
