### PR TITLE
Avoid reverse lookup when creating NodeEndPoint from SocketAddress

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -367,7 +367,7 @@ public class MemcachedConnection extends SpyThread implements ClusterConfigurati
     for(InetSocketAddress sa : socketAddressList){
       InetAddress addr = sa.getAddress();
       String ipAddress = (addr != null) ? addr.getHostAddress() : null;
-      NodeEndPoint endPoint = new NodeEndPoint(sa.getHostName(), ipAddress, sa.getPort());
+      NodeEndPoint endPoint = new NodeEndPoint(sa.getHostString(), ipAddress, sa.getPort());
       endPoints.add(endPoint);
     }
     

--- a/src/main/java/net/spy/memcached/config/NodeEndPoint.java
+++ b/src/main/java/net/spy/memcached/config/NodeEndPoint.java
@@ -74,7 +74,7 @@ public class NodeEndPoint {
   }
   
   public InetSocketAddress getInetSocketAddress(boolean reresolve){
-    if(reresolve == true || ipAddress == null || ipAddress.trim().equals("")){
+    if(reresolve || ipAddress == null || ipAddress.trim().equals("")){
       return new InetSocketAddress(hostName, port);
     } else {
       try {
@@ -94,12 +94,9 @@ public class NodeEndPoint {
   
   @Override
   public String toString(){
-    StringBuilder buffer = new StringBuilder("NodeEndPoint - ");
-    buffer.append("HostName:" + hostName);
-    buffer.append(" IpAddress:" + ipAddress);
-    buffer.append(" Port:" + port);
-    
-    return buffer.toString();
+    return "NodeEndPoint - " + "HostName:" + hostName +
+        " IpAddress:" + ipAddress +
+        " Port:" + port;
   }
 
 }


### PR DESCRIPTION
Note: this requires JDK 1.7