### PR TITLE
Fix bug invalid flush op result.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -2772,7 +2772,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public OperationFuture<Boolean> flush(final int delay) {
     final AtomicReference<Boolean> flushResult =
-        new AtomicReference<Boolean>(null);
+        new AtomicReference<Boolean>(true);
     final ConcurrentLinkedQueue<Operation> ops =
         new ConcurrentLinkedQueue<Operation>();
     CountDownLatch blatch = broadcastOp(new BroadcastOpFactory() {
@@ -2782,7 +2782,9 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
         Operation op = opFact.flush(delay, new OperationCallback() {
           @Override
           public void receivedStatus(OperationStatus s) {
-            flushResult.set(s.isSuccess());
+            if (!s.isSuccess()) {
+              flushResult.set(false);
+            }
           }
 
           @Override


### PR DESCRIPTION
The Broadcast operation sends all requests to N cache nodes.
This results in multiple responses from these nodes.

The traditional flush behavior only reflects the result of the most recently computed
op instance that was most recently computed.

This means that even if there is a failed operation, if the most recent operation was successful, the final result is computed as the final result is computed as success.

Change the implementation to set the result to false only if there is a failed operation.
