### PR TITLE
fix: reconnects keeps retrying on DNS resolution failures

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1148,6 +1148,9 @@ public class MemcachedConnection extends SpyThread {
       } catch (SocketException e) {
         getLogger().warn("Error on reconnect", e);
         rereQueue.add(node);
+      } catch (UnresolvedAddressException e) {
+        getLogger().warn("Unresolved Address error on reconnect", e);
+        rereQueue.add(node);
       } catch (Exception e) {
         getLogger().error("Exception on reconnect, lost node %s", node, e);
       } finally {


### PR DESCRIPTION
*Description of changes:*

### Problem description
On reconnect flow keep retrying not just for Socket exceptions but also for DNS resolution exceptions.

#### Detailed:
* On a new connection establishment ([createConnections](https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java/blob/c57e78c017d63e84c4ca169d629f2ed9f984720a/src/main/java/net/spy/memcached/MemcachedConnection.java#L495)) we handle DNS resolution failures and retrying by having a catch for name resolution exceptions (`UnresolvedAddressException`).
* But for re-connections (`attemptReconnects`) we don't, and in such cases the client stop retrying and connectivity is lost for good.
* We had a scenario where a client had network interruptions affecting both DNS and Memcached connections.
     * Memcached connections attempted retries (using FailureMode.Retry)
     * But DNS was not responsive at times, which thrown an exception which led to idleness on the client since it gave up on the connection instead of re-attempting. 

### Testing on a replication
The fix was verified on a replication setup to ensure it works.

1. We opened a connection to Memcached, use a hostname endpoint to be resolved by a DNS server.
      * We use FailureMode.Retry strategy.
2. We blocked connectivity to your DNS server
3. We blocked memcached TCP connections until the connection is expired/closed on server side
4. Waiting for the connection it get expired on the server, then remove the memcached block
5. Once the DNS cache is expired, we encounter `UnresolvedAddressException` as the DNS block is still enabled.
7. No retries would occur when it is in the attemptReconnects flow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
