### PR TITLE
Add getsBulk method to MemcachedClient

### DIFF
--- a/src/it/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/it/java/net/spy/memcached/ProtocolBaseCase.java
@@ -485,6 +485,91 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
+  public void testGetsBulkVararg() throws Exception {
+    assertEquals(0, client.getsBulk("test1", "test2", "test3").size());
+    client.set("test1", 5, "val1");
+    client.set("test2", 5, "val2");
+    Map<String, CASValue<Object>> vals = client.getsBulk("test1", "test2", "test3");
+    assertEquals(2, vals.size());
+    assertEquals("val1", vals.get("test1").getValue());
+    assertEquals("val2", vals.get("test2").getValue());
+    assertTrue(vals.get("test1").getCas() > 0);
+    assertTrue(vals.get("test2").getCas() > 0);
+  }
+
+  @Test
+  public void testGetsBulkVarargWithTranscoder() throws Exception {
+    Transcoder<String> t = new TestTranscoder();
+    assertEquals(0, client.getsBulk(t, "test1", "test2", "test3").size());
+    client.set("test1", 5, "val1", t);
+    client.set("test2", 5, "val2", t);
+    Map<String, CASValue<String>> vals = client.getsBulk(t, "test1", "test2", "test3");
+    assertEquals(2, vals.size());
+    assertEquals("val1", vals.get("test1").getValue());
+    assertEquals("val2", vals.get("test2").getValue());
+    assertTrue(vals.get("test1").getCas() > 0);
+    assertTrue(vals.get("test2").getCas() > 0);
+  }
+
+  @Test
+  public void testGetsBulkCollection() throws Exception {
+    Collection<String> keys = Arrays.asList("test1", "test2", "test3");
+    assertEquals(0, client.getsBulk(keys).size());
+    client.set("test1", 5, "val1");
+    client.set("test2", 5, "val2");
+    Map<String, CASValue<Object>> vals = client.getsBulk(keys);
+    assertEquals(2, vals.size());
+    assertEquals("val1", vals.get("test1").getValue());
+    assertEquals("val2", vals.get("test2").getValue());
+    assertTrue(vals.get("test1").getCas() > 0);
+    assertTrue(vals.get("test2").getCas() > 0);
+  }
+
+  @Test
+  public void testGetsBulkCollectionWithTranscoder() throws Exception {
+    Transcoder<String> t = new TestTranscoder();
+    Collection<String> keys = Arrays.asList("test1", "test2", "test3");
+    assertEquals(0, client.getsBulk(keys, t).size());
+    client.set("test1", 5, "val1", t);
+    client.set("test2", 5, "val2", t);
+    Map<String, CASValue<String>> vals = client.getsBulk(keys, t);
+    assertEquals(2, vals.size());
+    assertEquals("val1", vals.get("test1").getValue());
+    assertEquals("val2", vals.get("test2").getValue());
+    assertTrue(vals.get("test1").getCas() > 0);
+    assertTrue(vals.get("test2").getCas() > 0);
+  }
+
+  @Test
+  public void testGetsBulkIterator() throws Exception {
+    Collection<String> keys = Arrays.asList("test1", "test2", "test3");
+    assertEquals(0, client.getsBulk(keys.iterator()).size());
+    client.set("test1", 5, "val1");
+    client.set("test2", 5, "val2");
+    Map<String, CASValue<Object>> vals = client.getsBulk(keys.iterator());
+    assertEquals(2, vals.size());
+    assertEquals("val1", vals.get("test1").getValue());
+    assertEquals("val2", vals.get("test2").getValue());
+    assertTrue(vals.get("test1").getCas() > 0);
+    assertTrue(vals.get("test2").getCas() > 0);
+  }
+
+  @Test
+  public void testGetsBulkIteratorWithTranscoder() throws Exception {
+    Transcoder<String> t = new TestTranscoder();
+    Collection<String> keys = Arrays.asList("test1", "test2", "test3");
+    assertEquals(0, client.getsBulk(keys.iterator(), t).size());
+    client.set("test1", 5, "val1", t);
+    client.set("test2", 5, "val2", t);
+    Map<String, CASValue<String>> vals = client.getsBulk(keys.iterator(), t);
+    assertEquals(2, vals.size());
+    assertEquals("val1", vals.get("test1").getValue());
+    assertEquals("val2", vals.get("test2").getValue());
+    assertTrue(vals.get("test1").getCas() > 0);
+    assertTrue(vals.get("test2").getCas() > 0);
+  }
+
+  @Test
   public void testGetBulkVarargWithTranscoder() throws Exception {
     Transcoder<String> t = new TestTranscoder();
     assertEquals(0, client.getBulk(t, "test1", "test2", "test3").size());

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1620,6 +1620,111 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   }
 
   /**
+   * Asynchronously gets (with CAS support) a bunch of objects from the cache.
+   *
+   * @param <T>
+   * @param keyIter Iterator that produces keys.
+   * @param tcIter an iterator of transcoders to serialize and unserialize
+   *          values; the transcoders are matched with the keys in the same
+   *          order. The minimum of the key collection length and number of
+   *          transcoders is used and no exception is thrown if they do not
+   *          match
+   * @return a Future result of that fetch
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Iterator<String> keyIter,
+      Iterator<Transcoder<T>> tcIter) {
+    final Map<String, Future<CASValue<T>>> m = new ConcurrentHashMap<String, Future<CASValue<T>>>();
+
+    // This map does not need to be a ConcurrentHashMap
+    // because it is fully populated when it is used and
+    // used only to read the transcoder for a key.
+    final Map<String, Transcoder<T>> tcMap =
+            new HashMap<String, Transcoder<T>>();
+
+    // Break the gets down into groups by key
+    final Map<MemcachedNode, Collection<String>> chunks =
+            new HashMap<MemcachedNode, Collection<String>>();
+    final NodeLocator locator = mconn.getLocator();
+
+    while (keyIter.hasNext() && tcIter.hasNext()) {
+      String key = keyIter.next();
+      tcMap.put(key, tcIter.next());
+      StringUtils.validateKey(key, opFact instanceof BinaryOperationFactory);
+      final MemcachedNode primaryNode = locator.getPrimary(key);
+      MemcachedNode node = null;
+      if (primaryNode.isActive()) {
+        node = primaryNode;
+      } else {
+        for (Iterator<MemcachedNode> i = locator.getSequence(key); node == null
+                && i.hasNext();) {
+          MemcachedNode n = i.next();
+          if (n.isActive()) {
+            node = n;
+          }
+        }
+        if (node == null) {
+          node = primaryNode;
+        }
+      }
+      assert node != null : "Didn't find a node for " + key;
+      Collection<String> ks = chunks.get(node);
+      if (ks == null) {
+        ks = new ArrayList<String>();
+        chunks.put(node, ks);
+      }
+      ks.add(key);
+    }
+
+    final AtomicInteger pendingChunks = new AtomicInteger(chunks.size());
+    int initialLatchCount = chunks.isEmpty() ? 0 : 1;
+    final CountDownLatch latch = new CountDownLatch(initialLatchCount);
+    final Collection<Operation> ops = new ArrayList<Operation>(chunks.size());
+    final BulkGetFuture<CASValue<T>> rv = new BulkGetFuture<CASValue<T>>(m, ops, latch, executorService);
+
+    GetsOperation.Callback cb = new GetsOperation.Callback() {
+      @Override
+      @SuppressWarnings("synthetic-access")
+      public void receivedStatus(OperationStatus status) {
+        if (status.getStatusCode() == StatusCode.ERR_NOT_MY_VBUCKET) {
+          pendingChunks.addAndGet(Integer.parseInt(status.getMessage()));
+        }
+        rv.setStatus(status);
+      }
+
+      @Override
+      public void gotData(String k, int flags, long cas, byte[] data) {
+        Transcoder<T> tc = tcMap.get(k);
+        m.put(k, tcService.decodeCAS(tc, cas, new CachedData(flags, data, tc.getMaxSize())));
+      }
+
+      @Override
+      public void complete() {
+        if (pendingChunks.decrementAndGet() <= 0) {
+          latch.countDown();
+          rv.signalComplete();
+        }
+      }
+    };
+
+    // Now that we know how many servers it breaks down into, and the latch
+    // is all set up, convert all of these strings collections to operations
+    final Map<MemcachedNode, Operation> mops =
+            new HashMap<MemcachedNode, Operation>();
+
+    for (Map.Entry<MemcachedNode, Collection<String>> me : chunks.entrySet()) {
+      Operation op = opFact.gets(me.getValue(), cb);
+      mops.put(me.getKey(), op);
+      ops.add(op);
+    }
+    assert mops.size() == chunks.size();
+    mconn.checkState();
+    mconn.addOperations(mops);
+    return rv;
+  }
+
+  /**
    * Asynchronously get a bunch of objects from the cache.
    *
    * @param <T>
@@ -1640,6 +1745,27 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   }
 
   /**
+   * Asynchronously gets (with CAS support) a bunch of objects from the cache
+   * and decode them with the given transcoders.
+   *
+   * @param <T>
+   * @param keys the keys to request
+   * @param tcs an iterator of transcoders to serialize and unserialize values;
+   *           the transcoders are matched with the keys in the same order. The
+   *           minimum of the key collection length and the transcoder iterator
+   *           length is used and no exception is thrown if one is longer than
+   *           the other
+   * @return a Future result of that fetch
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  @Override
+  public <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Collection<String> keys,
+      Iterator<Transcoder<T>> tcs) {
+    return asyncGetsBulk(keys.iterator(), tcs);
+  }
+
+  /**
    * Asynchronously get a bunch of objects from the cache.
    *
    * @param <T>
@@ -1653,6 +1779,23 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   public <T> BulkFuture<Map<String, T>> asyncGetBulk(Iterator<String> keyIter,
       Transcoder<T> tc) {
     return asyncGetBulk(keyIter,
+            new SingleElementInfiniteIterator<Transcoder<T>>(tc));
+  }
+
+  /**
+   * Asynchronously gets (with CAS support) a bunch of objects from the cache
+   * and decode them with the given transcoder.
+   *
+   * @param <T>
+   * @param keyIter Iterator that produces the keys to request
+   * @param tc the transcoder to serialize and unserialize values
+   * @return a Future result of that fetch
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Iterator<String> keyIter,
+      Transcoder<T> tc) {
+    return asyncGetsBulk(keyIter,
             new SingleElementInfiniteIterator<Transcoder<T>>(tc));
   }
 
@@ -1674,6 +1817,22 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   }
 
   /**
+   * Asynchronously gets (with CAS support) a bunch of objects from the cache
+   * and decode them with the given transcoder.
+   *
+   * @param <T>
+   * @param keys the keys to request
+   * @param tc the transcoder to serialize and unserialize values
+   * @return a Future result of that fetch
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Collection<String> keys,
+      Transcoder<T> tc) {
+    return asyncGetsBulk(keys.iterator(), tc);
+  }
+
+  /**
    * Asynchronously get a bunch of objects from the cache and decode them with
    * the given transcoder.
    *
@@ -1689,6 +1848,20 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   }
 
   /**
+   * Asynchronously gets (with CAS support) a bunch of objects from the cache
+   * and decode them with the default transcoder.
+   *
+   * @param keyIter Iterator that produces the keys to request
+   * @return a Future result of that fetch
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(
+         Iterator<String> keyIter) {
+    return asyncGetsBulk(keyIter, transcoder);
+  }
+
+  /**
    * Asynchronously get a bunch of objects from the cache and decode them with
    * the given transcoder.
    *
@@ -1700,6 +1873,19 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public BulkFuture<Map<String, Object>> asyncGetBulk(Collection<String> keys) {
     return asyncGetBulk(keys, transcoder);
+  }
+
+  /**
+   * Asynchronously gets (with CAS support) a bunch of objects from the cache
+   * and decode them with the default transcoder.
+   *
+   * @param keys the keys to request
+   * @return a Future result of that fetch
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(Collection<String> keys) {
+    return asyncGetsBulk(keys, transcoder);
   }
 
   /**
@@ -1719,6 +1905,21 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   }
 
   /**
+   * Varargs wrapper for asynchronous bulk gets with CAS support.
+   *
+   * @param <T>
+   * @param tc the transcoder to serialize and unserialize value
+   * @param keys one more more keys to get
+   * @return the future values of those keys
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Transcoder<T> tc,
+      String... keys) {
+    return asyncGetsBulk(Arrays.asList(keys), tc);
+  }
+
+  /**
    * Varargs wrapper for asynchronous bulk gets with the default transcoder.
    *
    * @param keys one more more keys to get
@@ -1729,6 +1930,18 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public BulkFuture<Map<String, Object>> asyncGetBulk(String... keys) {
     return asyncGetBulk(Arrays.asList(keys), transcoder);
+  }
+
+  /**
+   * Varargs wrapper for asynchronous bulk gets with CAS support and the default transcoder.
+   *
+   * @param keys one more more keys to get
+   * @return the future values of those keys
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  public BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(String... keys) {
+    return asyncGetsBulk(Arrays.asList(keys), transcoder);
   }
 
   /**
@@ -1827,6 +2040,41 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   }
 
   /**
+   * Gets (with CAS support) the values for multiple keys from the cache.
+   *
+   * @param <T>
+   * @param keyIter Iterator that produces the keys
+   * @param tc the transcoder to serialize and unserialize value
+   * @return a map of the CAS values (for each value that exists)
+   * @throws OperationTimeoutException if the global operation timeout is
+   *           exceeded
+   * @throws CancellationException if operation was canceled
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  @Override
+  public <T> Map<String, CASValue<T>> getsBulk(Iterator<String> keyIter,
+      Transcoder<T> tc) {
+    try {
+      return asyncGetsBulk(keyIter, tc).get(operationTimeout,
+          TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted getting bulk values", e);
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof CancellationException) {
+        throw (CancellationException) e.getCause();
+      } else if (e.getCause() instanceof TimeoutException) {
+        throw new OperationTimeoutException("Timeout waiting for bulk values", e);
+      } else {
+        throw new RuntimeException("Exception waiting for bulk values", e);
+      }
+    } catch (TimeoutException e) {
+      throw new OperationTimeoutException("Timeout waiting for bulk values: "
+        + buildTimeoutMessage(operationTimeout, TimeUnit.MILLISECONDS), e);
+    }
+  }
+
+  /**
    * Get the values for multiple keys from the cache.
    *
    * @param keyIter Iterator that produces the keys
@@ -1839,6 +2087,21 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public Map<String, Object> getBulk(Iterator<String> keyIter) {
     return getBulk(keyIter, transcoder);
+  }
+
+  /**
+   * Gets (with CAS support) the values for multiple keys from the cache.
+   *
+   * @param keyIter Iterator that produces the keys
+   * @return a map of the CAS values (for each value that exists)
+   * @throws OperationTimeoutException if the global operation timeout is
+   *           exceeded
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  @Override
+  public Map<String, CASValue<Object>> getsBulk(Iterator<String> keyIter) {
+    return getsBulk(keyIter, transcoder);
   }
 
   /**
@@ -1860,6 +2123,24 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   }
 
   /**
+   * Gets (with CAS support) the values for multiple keys from the cache.
+   *
+   * @param <T>
+   * @param keys the keys
+   * @param tc the transcoder to serialize and unserialize value
+   * @return a map of the CAS values (for each value that exists)
+   * @throws OperationTimeoutException if the global operation timeout is
+   *           exceeded
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  @Override
+  public <T> Map<String, CASValue<T>> getsBulk(Collection<String> keys,
+      Transcoder<T> tc) {
+    return getsBulk(keys.iterator(), tc);
+  }
+
+  /**
    * Get the values for multiple keys from the cache.
    *
    * @param keys the keys
@@ -1872,6 +2153,21 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public Map<String, Object> getBulk(Collection<String> keys) {
     return getBulk(keys, transcoder);
+  }
+
+  /**
+   * Gets (with CAS support) the values for multiple keys from the cache.
+   *
+   * @param keys the keys
+   * @return a map of the CAS values (for each value that exists)
+   * @throws OperationTimeoutException if the global operation timeout is
+   *           exceeded
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  @Override
+  public Map<String, CASValue<Object>> getsBulk(Collection<String> keys) {
+    return getsBulk(keys, transcoder);
   }
 
   /**
@@ -1892,6 +2188,23 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   }
 
   /**
+   * Gets (with CAS support) the values for multiple keys from the cache.
+   *
+   * @param <T>
+   * @param tc the transcoder to serialize and unserialize value
+   * @param keys the keys
+   * @return a map of the CAS values (for each value that exists)
+   * @throws OperationTimeoutException if the global operation timeout is
+   *           exceeded
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  @Override
+  public <T> Map<String, CASValue<T>> getsBulk(Transcoder<T> tc, String... keys) {
+    return getsBulk(Arrays.asList(keys), tc);
+  }
+
+  /**
    * Get the values for multiple keys from the cache.
    *
    * @param keys the keys
@@ -1905,7 +2218,22 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   public Map<String, Object> getBulk(String... keys) {
     return getBulk(Arrays.asList(keys), transcoder);
   }
-  
+
+  /**
+   * Gets (with CAS support) the values for multiple keys from the cache.
+   *
+   * @param keys the keys
+   * @return a map of the CAS values (for each value that exists)
+   * @throws OperationTimeoutException if the global operation timeout is
+   *           exceeded
+   * @throws IllegalStateException in the rare circumstance where queue is too
+   *           full to accept any more requests
+   */
+  @Override
+  public Map<String, CASValue<Object>> getsBulk(String... keys) {
+    return getsBulk(Arrays.asList(keys), transcoder);
+  }
+
   private void enqueueOperation(String key, Operation op){
     checkState();
     mconn.enqueueOperation(key, op);

--- a/src/main/java/net/spy/memcached/MemcachedClientIF.java
+++ b/src/main/java/net/spy/memcached/MemcachedClientIF.java
@@ -153,6 +153,33 @@ public interface MemcachedClientIF {
 
   Map<String, Object> getBulk(String... keys);
 
+  <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Iterator<String> keys,
+      Iterator<Transcoder<T>> tcs);
+  <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Collection<String> keys,
+      Iterator<Transcoder<T>> tcs);
+
+  <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Iterator<String> keys,
+      Transcoder<T> tc);
+  <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Collection<String> keys,
+      Transcoder<T> tc);
+
+  BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(Iterator<String> keys);
+  BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(Collection<String> keys);
+
+  <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Transcoder<T> tc, String... keys);
+
+  BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(String... keys);
+
+  <T> Map<String, CASValue<T>> getsBulk(Iterator<String> keyIter, Transcoder<T> tc);
+  <T> Map<String, CASValue<T>> getsBulk(Collection<String> keys, Transcoder<T> tc);
+
+  Map<String, CASValue<Object>> getsBulk(Iterator<String> keyIter);
+  Map<String, CASValue<Object>> getsBulk(Collection<String> keys);
+
+  <T> Map<String, CASValue<T>> getsBulk(Transcoder<T> tc, String... keys);
+
+  Map<String, CASValue<Object>> getsBulk(String... keys);
+
   <T> Future<Boolean> touch(final String key, final int exp,
       final Transcoder<T> tc);
 

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -46,6 +46,7 @@ import net.spy.memcached.ops.TapOperation;
 import net.spy.memcached.ops.VBucketAware;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 import net.spy.memcached.protocol.binary.MultiGetOperationImpl;
+import net.spy.memcached.protocol.binary.MultiGetsOperationImpl;
 import net.spy.memcached.protocol.binary.TapAckOperationImpl;
 import net.spy.memcached.util.StringUtils;
 
@@ -1324,6 +1325,11 @@ public class MemcachedConnection extends SpyThread implements ClusterConfigurati
 
     if (op instanceof MultiGetOperationImpl) {
       for (String key : ((MultiGetOperationImpl) op).getRetryKeys()) {
+        addOperation(key, opFact.get(key,
+          (GetOperation.Callback) op.getCallback()));
+      }
+    } else if (op instanceof MultiGetsOperationImpl) {
+      for (String key : ((MultiGetsOperationImpl) op).getRetryKeys()) {
         addOperation(key, opFact.get(key,
           (GetOperation.Callback) op.getCallback()));
       }

--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -192,6 +192,15 @@ public interface OperationFactory {
    * @return a new GetsOperation
    */
   GetsOperation gets(String key, GetsOperation.Callback callback);
+  
+  /**
+   * Get a gets operation for multiple keys.
+   *
+   * @param keys the keys to get
+   * @param cb the callback that will contain the results
+   * @return the GetsOperation
+   */
+  GetsOperation gets(Collection<String> keys, GetsOperation.Callback cb);
 
   /**
    * Create a get operation.

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -126,6 +126,10 @@ public class AsciiOperationFactory extends BaseOperationFactory {
   public GetsOperation gets(String key, GetsOperation.Callback cb) {
     return new GetsOperationImpl(key, cb);
   }
+  
+  public GetsOperation gets(Collection<String> keys, GetsOperation.Callback cb) {
+    return new GetsOperationImpl(keys, cb);
+  }
 
   public StatsOperation keyStats(String key, Callback cb) {
     throw new UnsupportedOperationException("Key stats are not supported "

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetsOperationImpl.java
@@ -22,6 +22,7 @@
 
 package net.spy.memcached.protocol.ascii;
 
+import java.util.Collection;
 import java.util.Collections;
 
 import net.spy.memcached.ops.GetsOperation;
@@ -35,5 +36,9 @@ class GetsOperationImpl extends BaseGetOpImpl implements GetsOperation {
 
   public GetsOperationImpl(String key, GetsOperation.Callback cb) {
     super(CMD, cb, Collections.singleton(key));
+  }
+  
+  public GetsOperationImpl(Collection<String> keys, GetsOperation.Callback cb) {
+    super(CMD, cb, keys);
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -130,6 +130,10 @@ public class BinaryOperationFactory extends BaseOperationFactory {
   public GetsOperation gets(String key, GetsOperation.Callback cb) {
     return new GetsOperationImpl(key, cb);
   }
+  
+  public GetsOperation gets(Collection<String> keys, GetsOperation.Callback cb) {
+    return new MultiGetsOperationImpl(keys, cb);
+  }
 
   public StatsOperation keyStats(String key, StatsOperation.Callback cb) {
     return new KeyStatsOperationImpl(key, cb);

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiGetsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiGetsOperationImpl.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) 2006-2009 Dustin Sallings
+ * Copyright (C) 2009-2011 Couchbase, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
+
+package net.spy.memcached.protocol.binary;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import net.spy.memcached.KeyUtil;
+import net.spy.memcached.ops.GetsOperation;
+import net.spy.memcached.ops.OperationState;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatusCode;
+
+import static net.spy.memcached.protocol.binary.GetOperationImpl.EXTRA_HDR_LEN;
+
+/**
+ * Multi-gets operation for the binary protocol.
+ */
+public class MultiGetsOperationImpl extends MultiKeyOperationImpl implements
+    GetsOperation {
+
+  private static final byte CMD_GETQ = 0x09;
+
+  private final Map<Integer, String> keys = new HashMap<Integer, String>();
+  private final Map<Integer, byte[]> bkeys = new HashMap<Integer, byte[]>();
+  private final Map<String, Integer> rkeys = new HashMap<String, Integer>();
+
+  private final int terminalOpaque = generateOpaque();
+  private final List<String> retryKeys = new ArrayList<String>();
+
+  public MultiGetsOperationImpl(Collection<String> k, GetsOperation.Callback cb) {
+    super(DUMMY_OPCODE, -1, cb);
+    for (String s : new HashSet<String>(k)) {
+      addKey(s);
+    }
+  }
+
+  /**
+   * Add a key (and return its new opaque value).
+   */
+  protected int addKey(String k) {
+    Integer rv = rkeys.get(k);
+    if (rv == null) {
+      rv = generateOpaque();
+      keys.put(rv, k);
+      bkeys.put(rv, KeyUtil.getKeyBytes(k));
+      rkeys.put(k, rv);
+      synchronized (vbmap) {
+        vbmap.put(k, new Short((short) 0));
+      }
+    }
+    return rv;
+  }
+
+  @Override
+  public void initialize() {
+    int size = (1 + keys.size()) * MIN_RECV_PACKET;
+    for (byte[] b : bkeys.values()) {
+      size += b.length;
+    }
+    // set up the initial header stuff
+    ByteBuffer bb = ByteBuffer.allocate(size);
+    for (Map.Entry<Integer, byte[]> me : bkeys.entrySet()) {
+      final byte[] keyBytes = me.getValue();
+      final String key = keys.get(me.getKey());
+
+      // Custom header
+      bb.put(REQ_MAGIC);
+      bb.put(CMD_GETQ);
+      bb.putShort((short) keyBytes.length);
+      bb.put((byte) 0); // extralen
+      bb.put((byte) 0); // data type
+      bb.putShort(vbmap.get(key).shortValue()); // vbucket
+      bb.putInt(keyBytes.length);
+      bb.putInt(me.getKey());
+      bb.putLong(0); // cas
+      // the actual key
+      bb.put(keyBytes);
+    }
+    // Add the noop
+    bb.put(REQ_MAGIC);
+    bb.put((byte) NoopOperationImpl.CMD);
+    bb.putShort((short) 0);
+    bb.put((byte) 0); // extralen
+    bb.put((byte) 0); // data type
+    bb.putShort((short) 0); // reserved
+    bb.putInt(0);
+    bb.putInt(terminalOpaque);
+    bb.putLong(0); // cas
+
+    bb.flip();
+    setBuffer(bb);
+  }
+
+  @Override
+  protected void finishedPayload(byte[] pl) throws IOException {
+    getStatusForErrorCode(errorCode, pl);
+
+    if (responseOpaque == terminalOpaque) {
+      if (retryKeys.size() > 0) {
+        transitionState(OperationState.RETRY);
+        OperationStatus retryStatus = new OperationStatus(true,
+          Integer.toString(retryKeys.size()), StatusCode.ERR_NOT_MY_VBUCKET);
+        getCallback().receivedStatus(retryStatus);
+        getCallback().complete();
+      } else {
+        getCallback().receivedStatus(STATUS_OK);
+        transitionState(OperationState.COMPLETE);
+      }
+    } else if (errorCode == ERR_NOT_MY_VBUCKET) {
+      retryKeys.add(keys.get(responseOpaque));
+    } else if (errorCode != SUCCESS) {
+      getLogger().warn("Error on key %s:  %s (%d)", keys.get(responseOpaque),
+          new String(pl), errorCode);
+    } else {
+      final int flags = decodeInt(pl, 0);
+      final byte[] data = new byte[pl.length - EXTRA_HDR_LEN];
+      System.arraycopy(pl, EXTRA_HDR_LEN, data, 0, pl.length - EXTRA_HDR_LEN);
+      GetsOperation.Callback cb = (GetsOperation.Callback) getCallback();
+      cb.gotData(keys.get(responseOpaque), flags, responseCas, data);
+    }
+    resetInput();
+  }
+
+  @Override
+  protected boolean opaqueIsValid() {
+    return responseOpaque == terminalOpaque || keys.containsKey(responseOpaque);
+  }
+
+  /**
+   * Returns the keys to redistribute.
+   *
+   * @return the keys to retry.
+   */
+  public List<String> getRetryKeys() {
+    return retryKeys;
+  }
+}

--- a/src/main/java/net/spy/memcached/transcoders/TranscodeService.java
+++ b/src/main/java/net/spy/memcached/transcoders/TranscodeService.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import net.spy.memcached.CASValue;
 import net.spy.memcached.CachedData;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.internal.BasicThreadFactory;
@@ -61,6 +62,28 @@ public class TranscodeService extends SpyObject {
         new TranscodeService.Task<T>(new Callable<T>() {
           public T call() {
             return tc.decode(cachedData);
+          }
+        });
+
+    if (tc.asyncDecode(cachedData)) {
+      this.pool.execute(task);
+    }
+    return task;
+  }
+
+  /**
+   * Perform a decode of a CAS value.
+   */
+  public <T> Future<CASValue<T>> decodeCAS(final Transcoder<T> tc,
+      final long cas,
+      final CachedData cachedData) {
+
+    assert !pool.isShutdown() : "Pool has already shut down.";
+
+    TranscodeService.Task<CASValue<T>> task =
+        new TranscodeService.Task<CASValue<T>>(new Callable<CASValue<T>>() {
+          public CASValue<T> call() {
+            return new CASValue<T>(cas, tc.decode(cachedData));
           }
         });
 


### PR DESCRIPTION
Closes #50.

Adds a `getsBulk` method (bulk get with CAS identifiers), based on the implementation of `getBulk`.

IMO there's no real need for the duplication of `MultiGetsOperationImpl` and `MultiGetOperationImpl` (they could both be implemented with `MultiGetsOperationImpl` and `GetsOperation.Callback` with no performance loss), but I kept it for consistency and to avoid modifying existing code. Happy to change if requested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
