### PR TITLE
ISSUE-55 make config polling customizable

### DIFF
--- a/src/main/java/net/spy/memcached/ConfigurationPoller.java
+++ b/src/main/java/net/spy/memcached/ConfigurationPoller.java
@@ -7,10 +7,8 @@ package net.spy.memcached;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -20,6 +18,8 @@ import java.util.concurrent.TimeUnit;
 import net.spy.memcached.compat.SpyThread;
 import net.spy.memcached.config.ClusterConfiguration;
 import net.spy.memcached.config.ClusterConfigurationObserver;
+import net.spy.memcached.config.ConfigEndpointSelectionStrategy;
+import net.spy.memcached.config.RoundRobinConfigEndpointSelectionStrategy;
 import net.spy.memcached.config.NodeEndPoint;
 import net.spy.memcached.ops.ConfigurationType;
 import net.spy.memcached.transcoders.SerializingTranscoder;
@@ -46,21 +46,23 @@ public class ConfigurationPoller extends SpyThread{
   private ClusterConfiguration currentClusterConfiguration;
   //The transcoder used for config.
   private Transcoder<Object> configTranscoder = new SerializingTranscoder();
-  private int currentIndex = 0;
   private Date date = new Date();
   private long lastSuccessfulPoll = date.getTime(); 
   private int pollingErrorCount = 0;
+  private final ConfigEndpointSelectionStrategy configEndpointSelectionStrategy;
   
   //The executor is used to keep the task and it's execution independent. The scheduled thread polls takes care of 
   //the periodic polling.
   private ScheduledThreadPoolExecutor scheduledExecutor;
   
   public ConfigurationPoller(final MemcachedClient client){
-    this(client, DEFAULT_POLL_INTERVAL, false);
+    this(client, DEFAULT_POLL_INTERVAL, false, new RoundRobinConfigEndpointSelectionStrategy());
   }
   
-  public ConfigurationPoller(final MemcachedClient client, long pollingInterval, final boolean useDaemonThreads){
+  public ConfigurationPoller(final MemcachedClient client, long pollingInterval, final boolean useDaemonThreads,
+                             final ConfigEndpointSelectionStrategy configEndpointSelectionStrategy){
     this.client = client;
+    this.configEndpointSelectionStrategy = configEndpointSelectionStrategy;
     this.scheduledExecutor = new ScheduledThreadPoolExecutor(1, new ThreadFactory() {
 		@Override
 		public Thread newThread(Runnable runnable) {
@@ -90,21 +92,8 @@ public class ConfigurationPoller extends SpyThread{
     try{
       getLogger().info("Starting configuration poller.");
       String newConfigResponse = null;
-      NodeEndPoint endpointToGetConfig = null;
-    
-      Collection<NodeEndPoint> endpoints = client.getAvailableNodeEndPoints();
-      if(endpoints.isEmpty()){
-        //If no nodes are available status, then get all the endpoints. This provides an 
-        //oppurtunity to re-resolve the hostname by recreating InetSocketAddress instance in "NodeEndPoint".getInetSocketAddress().
-        endpoints = client.getAllNodeEndPoints();
-      }
-      currentIndex = (currentIndex+1)%endpoints.size();
-      Iterator<NodeEndPoint> iterator = endpoints.iterator();
-      for(int i =0;i<currentIndex;i++){
-        iterator.next();
-      }
+      NodeEndPoint endpointToGetConfig = configEndpointSelectionStrategy.getConfigEndpoint(client);
       
-      endpointToGetConfig = iterator.next();
       InetSocketAddress socketAddressToGetConfig = endpointToGetConfig.getInetSocketAddress();
       
       getLogger().info("Endpoint to use for configuration access in this poll " + endpointToGetConfig.toString());

--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -38,6 +38,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 
 import net.spy.memcached.auth.AuthDescriptor;
+import net.spy.memcached.config.ConfigEndpointSelectionStrategy;
 import net.spy.memcached.metrics.MetricCollector;
 import net.spy.memcached.metrics.MetricType;
 import net.spy.memcached.ops.Operation;
@@ -128,7 +129,13 @@ public interface ConnectionFactory {
    * @return the interval in milliseconds
    */
   long getDynamicModePollingInterval();
-  
+
+  /**
+   * The strategy used for selecting which endpoint to use when polling for cluster configuration.
+   * @return the configuration endpoint selection strategy
+   */
+  ConfigEndpointSelectionStrategy getConfigEndpointSelectionStrategy();
+
   /**
    * Get the operation timeout used by this connection.
    */

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -35,6 +35,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 
 import net.spy.memcached.auth.AuthDescriptor;
+import net.spy.memcached.config.ConfigEndpointSelectionStrategy;
 import net.spy.memcached.metrics.MetricCollector;
 import net.spy.memcached.metrics.MetricType;
 import net.spy.memcached.ops.Operation;
@@ -57,7 +58,9 @@ public class ConnectionFactoryBuilder {
   protected Transcoder<Object> transcoder;
 
   protected ClientMode clientMode;
-  
+
+  protected ConfigEndpointSelectionStrategy configEndpointSelectionStrategy;
+
   protected FailureMode failureMode;
 
   protected Collection<ConnectionObserver> initialObservers =
@@ -121,6 +124,7 @@ public class ConnectionFactoryBuilder {
     setSSLContext(cf.getSSLContext());
     setHostnameForTlsVerification(cf.getHostnameForTlsVerification());
     setSkipTlsHostnameVerification(cf.skipTlsHostnameVerification());
+    setConfigEndpointSelectionStrategy(cf.getConfigEndpointSelectionStrategy());
   }
 
   /**
@@ -130,6 +134,11 @@ public class ConnectionFactoryBuilder {
    */
   public ConnectionFactoryBuilder setClientMode(ClientMode clientMode){
     this.clientMode = clientMode;
+    return this;
+  }
+
+  public ConnectionFactoryBuilder setConfigEndpointSelectionStrategy(ConfigEndpointSelectionStrategy configEndpointSelectionStrategy){
+    this.configEndpointSelectionStrategy = configEndpointSelectionStrategy;
     return this;
   }
 
@@ -387,6 +396,13 @@ public class ConnectionFactoryBuilder {
       @Override
       public ClientMode getClientMode(){
         return clientMode == null ? super.getClientMode() : clientMode;
+      }
+
+      @Override
+      public ConfigEndpointSelectionStrategy getConfigEndpointSelectionStrategy() {
+        return configEndpointSelectionStrategy == null
+          ? super.getConfigEndpointSelectionStrategy()
+          : configEndpointSelectionStrategy;
       }
       
       @Override

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -42,6 +42,8 @@ import java.util.concurrent.TimeUnit;
 
 import net.spy.memcached.auth.AuthDescriptor;
 import net.spy.memcached.compat.SpyObject;
+import net.spy.memcached.config.ConfigEndpointSelectionStrategy;
+import net.spy.memcached.config.RoundRobinConfigEndpointSelectionStrategy;
 import net.spy.memcached.metrics.DefaultMetricCollector;
 import net.spy.memcached.metrics.MetricCollector;
 import net.spy.memcached.metrics.MetricType;
@@ -213,6 +215,10 @@ public class DefaultConnectionFactory extends SpyObject implements
 
   public long getDynamicModePollingInterval(){
     return ConfigurationPoller.DEFAULT_POLL_INTERVAL;
+  }
+
+  public ConfigEndpointSelectionStrategy getConfigEndpointSelectionStrategy() {
+    return new RoundRobinConfigEndpointSelectionStrategy();
   }
 
   public MemcachedNode createMemcachedNode(SocketAddress sa, SocketChannel c,

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -138,6 +138,7 @@ public class DefaultConnectionFactory extends SpyObject implements
   protected final int opQueueLen;
   private final int readBufSize;
   private final HashAlgorithm hashAlg;
+  private final ConfigEndpointSelectionStrategy configEndpointSelectionStrategy;
 
   private MetricCollector metrics;
 
@@ -164,6 +165,7 @@ public class DefaultConnectionFactory extends SpyObject implements
     this.readBufSize = bufSize;
     this.hashAlg = hash;
     this.metrics = null;
+    this.configEndpointSelectionStrategy = new RoundRobinConfigEndpointSelectionStrategy();
   }
 
   /**
@@ -218,7 +220,7 @@ public class DefaultConnectionFactory extends SpyObject implements
   }
 
   public ConfigEndpointSelectionStrategy getConfigEndpointSelectionStrategy() {
-    return new RoundRobinConfigEndpointSelectionStrategy();
+    return configEndpointSelectionStrategy;
   }
 
   public MemcachedNode createMemcachedNode(SocketAddress sa, SocketChannel c,

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -33,6 +33,7 @@ import net.spy.memcached.auth.AuthThreadMonitor;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.config.ClusterConfiguration;
 import net.spy.memcached.ConfigurationPoller;
+import net.spy.memcached.config.ConfigEndpointSelectionStrategy;
 import net.spy.memcached.config.NodeEndPoint;
 import net.spy.memcached.internal.BulkFuture;
 import net.spy.memcached.internal.BulkGetFuture;
@@ -191,6 +192,8 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
 
   protected final ExecutorService executorService;
 
+  protected final ConfigEndpointSelectionStrategy configEndpointSelectionStrategy;
+
   private NodeEndPoint configurationNode;
   //Set default value to true to attempt config API first. The value is set to false if
   //OperationNotSupportedException is thrown.
@@ -290,6 +293,8 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     authDescriptor = cf.getAuthDescriptor();
     executorService = cf.getListenerExecutorService();
 
+    configEndpointSelectionStrategy = cf.getConfigEndpointSelectionStrategy();
+
     if(clientMode == ClientMode.Dynamic){
       initializeClientUsingConfigEndPoint(cf, addrs.get(0));
     } else {
@@ -352,14 +357,14 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     }
     
     //Initialize and start the poller.
-    configPoller = new ConfigurationPoller(this, cf.getDynamicModePollingInterval(), cf.isDaemon());
+    configPoller = new ConfigurationPoller(this, cf.getDynamicModePollingInterval(), cf.isDaemon(), configEndpointSelectionStrategy);
     configPoller.subscribeForClusterConfiguration(mconn);
   }
 
   private void setupConnection(ConnectionFactory cf, List<InetSocketAddress> addrs)
     throws IOException {
 
-    mconn = cf.createConnection(addrs);
+    mconn = configEndpointSelectionStrategy.setupMemcachedConnection(cf, addrs);
     assert mconn != null : "Connection factory failed to make a connection";
   }
   
@@ -1996,7 +2001,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
       }
     });
     rv.setOperation(op);
-    mconn.enqueueOperation(addr, op);
+    configEndpointSelectionStrategy.getConfigConnection().enqueueOperation(addr, op);
     return rv;
   }
   
@@ -2046,7 +2051,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
             }
           });
     rv.setOperation(op);
-    mconn.enqueueOperation(addr, op);
+    configEndpointSelectionStrategy.getConfigConnection().enqueueOperation(addr, op);
     return rv;
   }
 
@@ -2073,7 +2078,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
       }
     });
     rv.setOperation(op);
-    mconn.enqueueOperation(addr, op);
+    configEndpointSelectionStrategy.getConfigConnection().enqueueOperation(addr, op);
     return rv;
   }
 
@@ -2988,6 +2993,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
         mconn.setName(baseName + " - SHUTTING DOWN (telling client)");
         mconn.shutdown();
         mconn.setName(baseName + " - SHUTTING DOWN (informed client)");
+        configEndpointSelectionStrategy.shutdownConfigConnection();
         tcService.shutdown();
         //terminate all pending Auth Threads
         authMonitor.interruptAllPendingAuth();

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -199,7 +199,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   //OperationNotSupportedException is thrown.
   private boolean isConfigurationProtocolSupported = true;
   
-  //This is used to dynamic mode to track whether the client is initialized with set of cache nodes for the first time.
+  // This is used in dynamic mode to track whether the client is initialized with a set of cache nodes for the first time.
   private boolean isConfigurationInitialized = false;
   
   private Transcoder<Object> configTranscoder = new SerializingTranscoder();
@@ -1296,7 +1296,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
       }
     });
     rv.setOperation(op);
-    mconn.enqueueOperation(sa, op);
+    configEndpointSelectionStrategy.getConfigConnection().enqueueOperation(sa, op);
     
     return rv;
   }

--- a/src/main/java/net/spy/memcached/MemcachedClientIF.java
+++ b/src/main/java/net/spy/memcached/MemcachedClientIF.java
@@ -101,6 +101,16 @@ public interface MemcachedClientIF {
 
   Future<Boolean> replace(String key, int exp, Object o);
 
+  /**
+   * @return point-in-time view of currently available servers
+   */
+  Collection<net.spy.memcached.config.NodeEndPoint> getAvailableNodeEndPoints();
+
+  /**
+   * @return point-in-time view of all servers
+   */
+  Collection<net.spy.memcached.config.NodeEndPoint> getAllNodeEndPoints();
+
   <T> Future<T> asyncGet(String key, Transcoder<T> tc);
 
   Future<Object> asyncGet(String key);

--- a/src/main/java/net/spy/memcached/config/ConfigEndpointSelectionStrategy.java
+++ b/src/main/java/net/spy/memcached/config/ConfigEndpointSelectionStrategy.java
@@ -1,0 +1,34 @@
+package net.spy.memcached.config;
+
+import net.spy.memcached.ConnectionFactory;
+import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.MemcachedConnection;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * A configuration endpoint selection strategy which
+ * holds information and lifecycle relating to the
+ * configuration endpoint connection opened.
+ */
+public interface ConfigEndpointSelectionStrategy {
+    /**
+     * An endpoint is different from a connection;
+     * A connection can may be composed of several endpoints
+     */
+    NodeEndPoint getConfigEndpoint(MemcachedClient client);
+    /**
+      * Delegate the responsibility of setting up a memcached connection to this class
+      * as depending on strategy, a copy of this memcached connection may be required
+      * to be created and kept alive
+      * @param cf connection factory used to build the Memcached connection
+      * @param addrs list of addresses that the connection factory should initialise connections with
+      * @return a Memcached connection in which memcached operations will be enqueued to
+      * @throws IOException
+      */
+    MemcachedConnection setupMemcachedConnection(ConnectionFactory cf, List<InetSocketAddress> addrs) throws IOException;
+    void shutdownConfigConnection() throws IOException;
+    MemcachedConnection getConfigConnection();
+}

--- a/src/main/java/net/spy/memcached/config/ConfigEndpointSelectionStrategy.java
+++ b/src/main/java/net/spy/memcached/config/ConfigEndpointSelectionStrategy.java
@@ -1,7 +1,7 @@
 package net.spy.memcached.config;
 
 import net.spy.memcached.ConnectionFactory;
-import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.MemcachedClientIF;
 import net.spy.memcached.MemcachedConnection;
 
 import java.io.IOException;
@@ -16,16 +16,16 @@ import java.util.List;
 public interface ConfigEndpointSelectionStrategy {
     /**
      * An endpoint is different from a connection;
-     * A connection can may be composed of several endpoints
+     * A connection could be composed of several endpoints
      */
-    NodeEndPoint getConfigEndpoint(MemcachedClient client);
+    NodeEndPoint getConfigEndpoint(MemcachedClientIF client);
     /**
       * Delegate the responsibility of setting up a memcached connection to this class
-      * as depending on strategy, a copy of this memcached connection may be required
+      * as, depending on the strategy, a copy of this memcached connection may be required
       * to be created and kept alive
       * @param cf connection factory used to build the Memcached connection
-      * @param addrs list of addresses that the connection factory should initialise connections with
-      * @return a Memcached connection in which memcached operations will be enqueued to
+      * @param addrs list of addresses that the connection factory should initialize connections with
+      * @return a Memcached connection to enqueue operations
       * @throws IOException
       */
     MemcachedConnection setupMemcachedConnection(ConnectionFactory cf, List<InetSocketAddress> addrs) throws IOException;

--- a/src/main/java/net/spy/memcached/config/RoundRobinConfigEndpointSelectionStrategy.java
+++ b/src/main/java/net/spy/memcached/config/RoundRobinConfigEndpointSelectionStrategy.java
@@ -1,0 +1,55 @@
+package net.spy.memcached.config;
+
+import net.spy.memcached.ConnectionFactory;
+import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.MemcachedConnection;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+public class RoundRobinConfigEndpointSelectionStrategy implements ConfigEndpointSelectionStrategy {
+    private int currentIndex = 0;
+    private MemcachedConnection configurationConnection;
+
+    @Override
+    public NodeEndPoint getConfigEndpoint(MemcachedClient client) {
+        Collection<NodeEndPoint> endpoints = client.getAvailableNodeEndPoints();
+        if (endpoints.isEmpty()) {
+            //If no nodes are available status, then get all the endpoints. This provides an
+            //opportunity to re-resolve the hostname by recreating InetSocketAddress instance in "NodeEndPoint".getInetSocketAddress().
+            endpoints = client.getAllNodeEndPoints();
+        }
+        currentIndex = (currentIndex + 1) % endpoints.size();
+        Iterator<NodeEndPoint> iterator = endpoints.iterator();
+        for (int i = 0; i < currentIndex; i++) {
+            iterator.next();
+        }
+        return iterator.next();
+    }
+
+    /**
+     * The Round Robin strategy (AWS default) reuses the same connection to retrieve configuration.
+     * In this case, we only need to hold a reference to the connection to return when
+     * `getConfigConnection` is called
+     *
+     */
+    public MemcachedConnection setupMemcachedConnection(ConnectionFactory cf, List<InetSocketAddress> addrs) throws IOException {
+        configurationConnection = cf.createConnection(addrs);
+        return configurationConnection;
+    }
+
+    @Override
+    public void shutdownConfigConnection() {
+        // As the Memcached connection doubles as a configuration connection,
+        // this operation is a no-op as that should be handled by the consumer of the
+        // Memcached connection
+    }
+
+    @Override
+    public MemcachedConnection getConfigConnection() {
+        return configurationConnection;
+    }
+}

--- a/src/main/java/net/spy/memcached/config/RoundRobinConfigEndpointSelectionStrategy.java
+++ b/src/main/java/net/spy/memcached/config/RoundRobinConfigEndpointSelectionStrategy.java
@@ -1,7 +1,7 @@
 package net.spy.memcached.config;
 
 import net.spy.memcached.ConnectionFactory;
-import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.MemcachedClientIF;
 import net.spy.memcached.MemcachedConnection;
 
 import java.io.IOException;
@@ -15,7 +15,7 @@ public class RoundRobinConfigEndpointSelectionStrategy implements ConfigEndpoint
     private MemcachedConnection configurationConnection;
 
     @Override
-    public NodeEndPoint getConfigEndpoint(MemcachedClient client) {
+    public NodeEndPoint getConfigEndpoint(MemcachedClientIF client) {
         Collection<NodeEndPoint> endpoints = client.getAvailableNodeEndPoints();
         if (endpoints.isEmpty()) {
             //If no nodes are available status, then get all the endpoints. This provides an
@@ -36,6 +36,7 @@ public class RoundRobinConfigEndpointSelectionStrategy implements ConfigEndpoint
      * `getConfigConnection` is called
      *
      */
+    @Override
     public MemcachedConnection setupMemcachedConnection(ConnectionFactory cf, List<InetSocketAddress> addrs) throws IOException {
         configurationConnection = cf.createConnection(addrs);
         return configurationConnection;

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -38,6 +38,8 @@ import net.spy.memcached.ConnectionFactoryBuilder.Protocol;
 import net.spy.memcached.auth.AuthDescriptor;
 import net.spy.memcached.auth.PlainCallbackHandler;
 import net.spy.memcached.compat.BaseMockCase;
+import net.spy.memcached.config.ConfigEndpointSelectionStrategy;
+import net.spy.memcached.config.RoundRobinConfigEndpointSelectionStrategy;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationQueueFactory;
 import net.spy.memcached.protocol.ascii.AsciiMemcachedNodeImpl;
@@ -106,6 +108,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
         DefaultConnectionFactory.DEFAULT_OP_QUEUE_MAX_BLOCK_TIME);
     assertEquals(f.getAuthWaitTime(),
       DefaultConnectionFactory.DEFAULT_AUTH_WAIT_TIME);
+    assertTrue(f.getConfigEndpointSelectionStrategy() instanceof RoundRobinConfigEndpointSelectionStrategy);
   }
 
   public void testModifications() throws Exception {
@@ -200,6 +203,13 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
     factory = b.build();
     assertFalse(factory.isDefaultExecutorService());
     assertEquals(service.hashCode(), factory.getListenerExecutorService().hashCode());
+  }
+
+  public void testSetConfigEndpointSelectionStrategy() {
+    ConfigEndpointSelectionStrategy strategy = (ConfigEndpointSelectionStrategy) mock(ConfigEndpointSelectionStrategy.class).proxy();
+    b.setConfigEndpointSelectionStrategy(strategy);
+    ConnectionFactory f = b.build();
+    assertSame(strategy, f.getConfigEndpointSelectionStrategy());
   }
 
   static class DirectFactory implements OperationQueueFactory {

--- a/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
@@ -49,6 +49,15 @@ public class ConnectionFactoryTest extends TestCase {
     new BinaryConnectionFactory(ClientMode.Static, 5, 5, DefaultHashAlgorithm.FNV1_64_HASH);
   }
 
+  public void testQueueSizes() {
+    ConnectionFactory cf = new DefaultConnectionFactory(100, 1024);
+    assertEquals(100, cf.createOperationQueue().remainingCapacity());
+    assertEquals(Integer.MAX_VALUE, cf.createWriteOperationQueue()
+        .remainingCapacity());
+    assertEquals(Integer.MAX_VALUE, cf.createReadOperationQueue()
+        .remainingCapacity());
+  }
+
   public void testDefaultConfigEndpointSelectionStrategy() {
     DefaultConnectionFactory cf = new DefaultConnectionFactory();
     assertTrue(cf.getConfigEndpointSelectionStrategy() instanceof RoundRobinConfigEndpointSelectionStrategy);

--- a/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
@@ -28,6 +28,7 @@
 package net.spy.memcached;
 
 import junit.framework.TestCase;
+import net.spy.memcached.config.RoundRobinConfigEndpointSelectionStrategy;
 
 /**
  * Test connection factory variations.
@@ -48,12 +49,8 @@ public class ConnectionFactoryTest extends TestCase {
     new BinaryConnectionFactory(ClientMode.Static, 5, 5, DefaultHashAlgorithm.FNV1_64_HASH);
   }
 
-  public void testQueueSizes() {
-    ConnectionFactory cf = new DefaultConnectionFactory(100, 1024);
-    assertEquals(100, cf.createOperationQueue().remainingCapacity());
-    assertEquals(Integer.MAX_VALUE, cf.createWriteOperationQueue()
-        .remainingCapacity());
-    assertEquals(Integer.MAX_VALUE, cf.createReadOperationQueue()
-        .remainingCapacity());
+  public void testDefaultConfigEndpointSelectionStrategy() {
+    DefaultConnectionFactory cf = new DefaultConnectionFactory();
+    assertTrue(cf.getConfigEndpointSelectionStrategy() instanceof RoundRobinConfigEndpointSelectionStrategy);
   }
 }

--- a/src/test/java/net/spy/memcached/config/RoundRobinConfigEndpointSelectionStrategyTest.java
+++ b/src/test/java/net/spy/memcached/config/RoundRobinConfigEndpointSelectionStrategyTest.java
@@ -1,0 +1,76 @@
+package net.spy.memcached.config;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Collection;
+
+import net.spy.memcached.UnitTestConfig;
+import org.jmock.Mock;
+import org.jmock.MockObjectTestCase;
+import net.spy.memcached.MemcachedClientIF;
+import net.spy.memcached.MemcachedConnection;
+import net.spy.memcached.DefaultConnectionFactory;
+
+import static net.spy.memcached.UnitTestConfig.PORT_NUMBER;
+
+public class RoundRobinConfigEndpointSelectionStrategyTest extends MockObjectTestCase {
+
+    private RoundRobinConfigEndpointSelectionStrategy strategy;
+    private Mock clientMock;
+    private MemcachedClientIF client;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        strategy = new RoundRobinConfigEndpointSelectionStrategy();
+        clientMock = mock(MemcachedClientIF.class);
+        client = (MemcachedClientIF) clientMock.proxy();
+    }
+
+    public void testGetConfigEndpointRoundRobin() {
+        List<NodeEndPoint> endpoints = new ArrayList<NodeEndPoint>();
+        endpoints.add(new NodeEndPoint("host1", PORT_NUMBER));
+        endpoints.add(new NodeEndPoint("host2", PORT_NUMBER));
+        endpoints.add(new NodeEndPoint("host3", PORT_NUMBER));
+
+        clientMock.expects(atLeastOnce()).method("getAvailableNodeEndPoints").will(returnValue(endpoints));
+
+        // Round robin should start from (0 + 1) % 3 = 1
+        assertEquals("host2", strategy.getConfigEndpoint(client).getHostName());
+        // Next (1 + 1) % 3 = 2
+        assertEquals("host3", strategy.getConfigEndpoint(client).getHostName());
+        // Next (2 + 1) % 3 = 0
+        assertEquals("host1", strategy.getConfigEndpoint(client).getHostName());
+        // Next (0 + 1) % 3 = 1
+        assertEquals("host2", strategy.getConfigEndpoint(client).getHostName());
+    }
+
+    public void testGetConfigEndpointWhenAvailableIsEmpty() {
+        List<NodeEndPoint> availableEndpoints = new ArrayList<NodeEndPoint>();
+        List<NodeEndPoint> allEndpoints = new ArrayList<NodeEndPoint>();
+        allEndpoints.add(new NodeEndPoint("host1", PORT_NUMBER));
+        allEndpoints.add(new NodeEndPoint("host2", PORT_NUMBER));
+
+        clientMock.expects(once()).method("getAvailableNodeEndPoints").will(returnValue(availableEndpoints));
+        clientMock.expects(once()).method("getAllNodeEndPoints").will(returnValue(allEndpoints));
+
+        // Should fall back to allEndpoints and start at (0 + 1) % 2 = 1
+        assertEquals("host2", strategy.getConfigEndpoint(client).getHostName());
+        
+        // Reset or just expect another call if we want to test next element
+        clientMock.expects(once()).method("getAvailableNodeEndPoints").will(returnValue(availableEndpoints));
+        clientMock.expects(once()).method("getAllNodeEndPoints").will(returnValue(allEndpoints));
+        assertEquals("host1", strategy.getConfigEndpoint(client).getHostName());
+    }
+
+    public void testSetupAndGetMemcachedConnection() throws Exception {
+        DefaultConnectionFactory cf = new DefaultConnectionFactory();
+        List<InetSocketAddress> addrs = new ArrayList<InetSocketAddress>();
+        addrs.add(new InetSocketAddress(UnitTestConfig.IPV4_ADDR, PORT_NUMBER));
+
+        MemcachedConnection conn = strategy.setupMemcachedConnection(cf, addrs);
+        assertNotNull(conn);
+        assertSame(conn, strategy.getConfigConnection());
+    }
+}


### PR DESCRIPTION
*Issue #55*

*Description of changes:*
Move config host selection logic to a separate class behind an interface, so it can be configured via `ConnectionFactory` on creation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
